### PR TITLE
npm package: hybrid cjs+esm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+dist/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -46,11 +46,16 @@ console.log(labels.base.macchiato.hex) // #24273A
 
 ### CSS
 
-Example: `test.css`
+Import the palettes:
 
 ```css
-@import url('https://unpkg.com/@catppuccin/palette@0.1.1/css/catppuccin.css');
+@import "@catppuccin/palette/style"		/* directly from the file */
+@import url('https://unpkg.com/@catppuccin/palette@0.1.4/css/catppuccin.css');		/* or using unpkg.com */
+```
 
+Then use them:
+
+```css
 body {
 	color: var(--ctp-mocha-text);
 	background: var(--ctp-frappe-base);

--- a/esbuild.js
+++ b/esbuild.js
@@ -1,0 +1,15 @@
+const esbuild = require('esbuild');
+
+const buildCJS = esbuild.build({
+    entryPoints: ['./index.js'],
+    outfile: './dist/index.cjs',
+    format: 'cjs'
+})
+
+const buildESM = esbuild.build({
+    entryPoints: ['./index.js'],
+    outfile: './dist/index.mjs',
+    format: 'esm'
+})
+
+Promise.all([buildCJS, buildESM]).catch(() => process.exit(1))

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 	},
 	"files": [
 		"css/",
-		"dist/index.js",
+		"dist/index.cjs",
 		"dist/index.mjs",
 		"index.d.ts"
 	],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
 	"description": "Soothing pastel themes for the high-spirited!",
 	"main": "index.js",
 	"type": "module",
-	"exports": "./index.js",
+	"exports": {
+		".": "./index.js",
+		"./style": "./css/catppuccin.css"
+	},
 	"scripts": {
 		"test": "ava"
 	},

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "@catppuccin/palette",
 	"version": "0.1.5",
-    "description": "Soothing pastel themes for the high-spirited!",
+	"description": "Soothing pastel themes for the high-spirited!",
 	"main": "dist/index.js",
-    "module": "dist/index.mjs",
+	"module": "dist/index.mjs",
 	"exports": {
 		".": {
 			"require": "./dist/index.js",
@@ -12,15 +12,15 @@
 	},
 	"scripts": {
 		"test": "ava",
-        "build": "npm run build:cjs && npm run build:esm",
-        "build:cjs": "esbuild index.js --minify --format=cjs --outdir=dist",
+		"build": "npm run build:cjs && npm run build:esm",
+		"build:cjs": "esbuild index.js --minify --format=cjs --outdir=dist",
 		"build:esm": "esbuild index.js --minify --format=esm --outdir=dist --out-extension:.js=.mjs",
 		"prepublishOnly": "npm run build"
 	},
 	"files": [
 		"css/",
 		"dist/index.js",
-        "dist/index.mjs",
+		"dist/index.mjs",
 		"index.d.ts"
 	],
 	"types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,26 @@
 {
 	"name": "@catppuccin/palette",
-	"version": "0.1.4",
-	"description": "Soothing pastel themes for the high-spirited!",
-	"main": "index.js",
-	"type": "module",
-	"exports": "./index.js",
+	"version": "0.1.5",
+    "description": "Soothing pastel themes for the high-spirited!",
+	"main": "dist/index.js",
+    "module": "dist/index.mjs",
+	"exports": {
+		".": {
+			"require": "./dist/index.js",
+			"import": "./dist/index.mjs"
+		}
+	},
 	"scripts": {
-		"test": "ava"
+		"test": "ava",
+        "build": "npm run build:cjs && npm run build:esm",
+        "build:cjs": "esbuild index.js --minify --format=cjs --outdir=dist",
+		"build:esm": "esbuild index.js --minify --format=esm --outdir=dist --out-extension:.js=.mjs",
+		"prepublishOnly": "npm run build"
 	},
 	"files": [
 		"css/",
-		"index.js",
+		"dist/index.js",
+        "dist/index.mjs",
 		"index.d.ts"
 	],
 	"types": "index.d.ts",
@@ -36,6 +46,7 @@
 	},
 	"homepage": "https://github.com/catppuccin/palette#readme",
 	"devDependencies": {
-		"ava": "^4.2.0"
+		"ava": "^4.2.0",
+		"esbuild": "^0.14.42"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -6,16 +6,14 @@
 	"module": "dist/index.mjs",
 	"exports": {
 		".": {
-			"require": "./dist/index.js",
+			"require": "./dist/index.cjs",
 			"import": "./dist/index.mjs"
 		},
         "./style": "./css/catppuccin.css"
     },
 	"scripts": {
 		"test": "ava",
-		"build": "npm run build:cjs && npm run build:esm",
-		"build:cjs": "esbuild index.js --minify --format=cjs --outdir=dist",
-		"build:esm": "esbuild index.js --minify --format=esm --outdir=dist --out-extension:.js=.mjs",
+		"build": "node esbuild.js",
 		"prepublishOnly": "npm run build"
 	},
 	"files": [

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
 			"require": "./dist/index.cjs",
 			"import": "./dist/index.mjs"
 		},
-        "./style": "./css/catppuccin.css"
-    },
+		"./style": "./css/catppuccin.css"
+	},
 	"scripts": {
 		"test": "ava",
 		"build": "node esbuild.js",


### PR DESCRIPTION
Hi there! 👋 

I noticed that the npm package only supports `import`, so I added support for `require()` .
This PR adds `esbuild` as a devDep to build both formats; please let me know if you'd prefer a different solution.