### PR TITLE
feat: add python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     - [Sass](#sass)
     - [Tailwind CSS](https://github.com/catppuccin/tailwindcss) (separate repository)
     - [Rust](#rust)
+    - [Python](#python)
 - Design
     - [Affinity](#affinity)
     - [Aseprite / LibreSprite](#aseprite)
@@ -89,6 +90,17 @@ cargo add catppuccin
 
 More information and examples can be found on [crates.io](https://crates.io/crates/catppuccin), [docs.rs](https://docs.rs/catppuccin/latest/catppuccin/),
 and in the [`rust`](https://github.com/catppuccin/palette/tree/main/rust) folder.
+
+### Python
+
+Install the package with `pip` or the dependency management tool of your choice:
+
+```bash
+pip install catppuccin
+```
+
+Documentation and examples can be found in the
+[`python`](https://github.com/catppuccin/palette/tree/main/python) folder.
 
 ### Affinity
 

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,3 @@
+.venv
+__pycache__/
+.coverage

--- a/python/README.md
+++ b/python/README.md
@@ -58,8 +58,8 @@ poetry install
 
 ### Code Standards
 
-Before committing changes, it is recommended to run the follow tools to ensure
-consistency in the codebase.
+Before committing changes, it is recommended to run the following tools to
+ensure consistency in the codebase.
 
 ```bash
 isort .

--- a/python/README.md
+++ b/python/README.md
@@ -38,15 +38,25 @@ mantle: #292c3c
 crust: #232634
 ```
 
-## Development
+## Contribution
 
-Install dependencies with [poetry](https://python-poetry.org):
+If you are looking to contribute, please read through our
+[CONTRIBUTING.md](https://github.com/catppuccin/.github/blob/main/CONTRIBUTING.md)
+first!
+
+### Setup
+
+This project is maintained with [Poetry](https://python-poetry.org). If you
+don't have Poetry yet, you can install it using the [installation
+instructions](https://python-poetry.org/docs/#installation).
+
+Install the project's dependencies:
 
 ```bash
 poetry install
 ```
 
-## Code Standards
+### Code Standards
 
 Before committing changes, it is recommended to run the follow tools to ensure
 consistency in the codebase.
@@ -59,5 +69,7 @@ mypy .
 pytest --cov
 ```
 
-These tools are all installed as part of the `dev` dependency group.
+These tools are all installed as part of the `dev` dependency group with
+Poetry. You can use `poetry shell` to automatically put these tools in your
+path.
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,63 @@
+# catppuccin
+
+🐍 Soothing pastel theme for Python.
+
+## Usage
+
+Install with `pip` or your preferred dependency management tool.
+
+```bash
+pip install catppuccin
+```
+
+## Example
+
+```python
+>>> from catppuccin import Flavour
+>>> Flavour.latte().mauve.hex
+'8839ef'
+>>> Flavour.mocha().teal.rgb
+(148, 226, 213)
+```
+
+`Flavour` is a [`dataclass`](https://docs.python.org/3/library/dataclasses.html),
+so you can inspect its fields to get access to the full set of colour names and values:
+
+```python
+>>> from dataclasses import fields
+>>> flavour = Flavour.frappe()
+>>> for field in fields(flavour):
+        colour = getattr(flavour, field.name)
+        print(f"{field.name}: #{colour.hex}")
+rosewater: #f2d5cf
+flamingo: #eebebe
+pink: #f4b8e4
+...
+base: #303446
+mantle: #292c3c
+crust: #232634
+```
+
+## Development
+
+Install dependencies with [poetry](https://python-poetry.org):
+
+```bash
+poetry install
+```
+
+## Code Standards
+
+Before committing changes, it is recommended to run the follow tools to ensure
+consistency in the codebase.
+
+```bash
+isort .
+black .
+pylint catppuccin.py
+mypy .
+pytest --cov
+```
+
+These tools are all installed as part of the `dev` dependency group.
+

--- a/python/catppuccin.py
+++ b/python/catppuccin.py
@@ -1,0 +1,181 @@
+"""🐍 Soothing pastel theme for Python."""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Colour:
+    """A colour with three channels; red, green, and blue."""
+
+    red: int
+    green: int
+    blue: int
+
+    @property
+    def rgb(self) -> tuple[int, int, int]:
+        """Get the colour as a 3-tuple of red, green, and blue."""
+        return (self.red, self.green, self.blue)
+
+    @property
+    def hex(self) -> str:
+        """Get the colour as a lowercase hex string."""
+        return f"{self.red:02x}{self.green:02x}{self.blue:02x}"
+
+
+@dataclass(frozen=True)
+class Flavour:  # pylint: disable=too-many-instance-attributes
+    """All the colours in a flavour of Catppuccin."""
+
+    rosewater: Colour
+    flamingo: Colour
+    pink: Colour
+    mauve: Colour
+    red: Colour
+    maroon: Colour
+    peach: Colour
+    yellow: Colour
+    green: Colour
+    teal: Colour
+    sky: Colour
+    sapphire: Colour
+    blue: Colour
+    lavender: Colour
+    text: Colour
+    subtext1: Colour
+    subtext0: Colour
+    overlay2: Colour
+    overlay1: Colour
+    overlay0: Colour
+    surface2: Colour
+    surface1: Colour
+    surface0: Colour
+    base: Colour
+    mantle: Colour
+    crust: Colour
+
+    @staticmethod
+    def latte() -> "Flavour":
+        """Latte flavoured Catppuccin."""
+        return Flavour(
+            rosewater=Colour(220, 138, 120),
+            flamingo=Colour(221, 120, 120),
+            pink=Colour(234, 118, 203),
+            mauve=Colour(136, 57, 239),
+            red=Colour(210, 15, 57),
+            maroon=Colour(230, 69, 83),
+            peach=Colour(254, 100, 11),
+            yellow=Colour(223, 142, 29),
+            green=Colour(64, 160, 43),
+            teal=Colour(23, 146, 153),
+            sky=Colour(4, 165, 229),
+            sapphire=Colour(32, 159, 181),
+            blue=Colour(30, 102, 245),
+            lavender=Colour(114, 135, 253),
+            text=Colour(76, 79, 105),
+            subtext1=Colour(92, 95, 119),
+            subtext0=Colour(108, 111, 133),
+            overlay2=Colour(124, 127, 147),
+            overlay1=Colour(140, 143, 161),
+            overlay0=Colour(156, 160, 176),
+            surface2=Colour(172, 176, 190),
+            surface1=Colour(188, 192, 204),
+            surface0=Colour(204, 208, 218),
+            base=Colour(239, 241, 245),
+            mantle=Colour(230, 233, 239),
+            crust=Colour(220, 224, 232),
+        )
+
+    @staticmethod
+    def frappe() -> "Flavour":
+        """Frappé flavoured Catppuccin."""
+        return Flavour(
+            rosewater=Colour(242, 213, 207),
+            flamingo=Colour(238, 190, 190),
+            pink=Colour(244, 184, 228),
+            mauve=Colour(202, 158, 230),
+            red=Colour(231, 130, 132),
+            maroon=Colour(234, 153, 156),
+            peach=Colour(239, 159, 118),
+            yellow=Colour(229, 200, 144),
+            green=Colour(166, 209, 137),
+            teal=Colour(129, 200, 190),
+            sky=Colour(153, 209, 219),
+            sapphire=Colour(133, 193, 220),
+            blue=Colour(140, 170, 238),
+            lavender=Colour(186, 187, 241),
+            text=Colour(198, 208, 245),
+            subtext1=Colour(181, 191, 226),
+            subtext0=Colour(165, 173, 206),
+            overlay2=Colour(148, 156, 187),
+            overlay1=Colour(131, 139, 167),
+            overlay0=Colour(115, 121, 148),
+            surface2=Colour(98, 104, 128),
+            surface1=Colour(81, 87, 109),
+            surface0=Colour(65, 69, 89),
+            base=Colour(48, 52, 70),
+            mantle=Colour(41, 44, 60),
+            crust=Colour(35, 38, 52),
+        )
+
+    @staticmethod
+    def macchiato() -> "Flavour":
+        """Macchiato flavoured Catppuccin."""
+        return Flavour(
+            rosewater=Colour(244, 219, 214),
+            flamingo=Colour(240, 198, 198),
+            pink=Colour(245, 189, 230),
+            mauve=Colour(198, 160, 246),
+            red=Colour(237, 135, 150),
+            maroon=Colour(238, 153, 160),
+            peach=Colour(245, 169, 127),
+            yellow=Colour(238, 212, 159),
+            green=Colour(166, 218, 149),
+            teal=Colour(139, 213, 202),
+            sky=Colour(145, 215, 227),
+            sapphire=Colour(125, 196, 228),
+            blue=Colour(138, 173, 244),
+            lavender=Colour(183, 189, 248),
+            text=Colour(202, 211, 245),
+            subtext1=Colour(184, 192, 224),
+            subtext0=Colour(165, 173, 203),
+            overlay2=Colour(147, 154, 183),
+            overlay1=Colour(128, 135, 162),
+            overlay0=Colour(110, 115, 141),
+            surface2=Colour(91, 96, 120),
+            surface1=Colour(73, 77, 100),
+            surface0=Colour(54, 58, 79),
+            base=Colour(36, 39, 58),
+            mantle=Colour(30, 32, 48),
+            crust=Colour(24, 25, 38),
+        )
+
+    @staticmethod
+    def mocha() -> "Flavour":
+        """Mocha flavoured Catppuccin."""
+        return Flavour(
+            rosewater=Colour(245, 224, 220),
+            flamingo=Colour(242, 205, 205),
+            pink=Colour(245, 194, 231),
+            mauve=Colour(203, 166, 247),
+            red=Colour(243, 139, 168),
+            maroon=Colour(235, 160, 172),
+            peach=Colour(250, 179, 135),
+            yellow=Colour(249, 226, 175),
+            green=Colour(166, 227, 161),
+            teal=Colour(148, 226, 213),
+            sky=Colour(137, 220, 235),
+            sapphire=Colour(116, 199, 236),
+            blue=Colour(137, 180, 250),
+            lavender=Colour(180, 190, 254),
+            text=Colour(205, 214, 244),
+            subtext1=Colour(186, 194, 222),
+            subtext0=Colour(166, 173, 200),
+            overlay2=Colour(147, 153, 178),
+            overlay1=Colour(127, 132, 156),
+            overlay0=Colour(108, 112, 134),
+            surface2=Colour(88, 91, 112),
+            surface1=Colour(69, 71, 90),
+            surface0=Colour(49, 50, 68),
+            base=Colour(30, 30, 46),
+            mantle=Colour(24, 24, 37),
+            crust=Colour(17, 17, 27),
+        )

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -1,0 +1,672 @@
+[[package]]
+name = "astroid"
+version = "2.12.12"
+description = "An abstract syntax tree for Python with inference support."
+category = "dev"
+optional = false
+python-versions = ">=3.7.2"
+
+[package.dependencies]
+lazy-object-proxy = ">=1.4.0"
+typed-ast = {version = ">=1.4.0,<2.0", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
+typing-extensions = {version = ">=3.10", markers = "python_version < \"3.10\""}
+wrapt = [
+    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
+    {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
+]
+
+[[package]]
+name = "attrs"
+version = "22.1.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+
+[[package]]
+name = "black"
+version = "22.10.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+
+[[package]]
+name = "coverage"
+version = "6.5.0"
+description = "Code coverage measurement for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
+name = "dill"
+version = "0.3.6"
+description = "serialize all of python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+graph = ["objgraph (>=1.7.2)"]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.0.0rc9"
+description = "Backport of PEP 654 (exception groups)"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
+name = "importlib-metadata"
+version = "5.0.0"
+description = "Read metadata from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+perf = ["ipython"]
+testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "isort"
+version = "5.10.1"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0"
+
+[package.extras]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
+
+[[package]]
+name = "lazy-object-proxy"
+version = "1.8.0"
+description = "A fast and thorough lazy object proxy."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "mypy"
+version = "0.982"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typed-ast = {version = ">=1.4.0,<2", markers = "python_version < \"3.8\""}
+typing-extensions = ">=3.10"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pathspec"
+version = "0.10.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "platformdirs"
+version = "2.5.2"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pylint"
+version = "2.15.5"
+description = "python code static checker"
+category = "dev"
+optional = false
+python-versions = ">=3.7.2"
+
+[package.dependencies]
+astroid = ">=2.12.12,<=2.14.0-dev0"
+colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
+dill = ">=0.2"
+isort = ">=4.2.5,<6"
+mccabe = ">=0.6,<0.8"
+platformdirs = ">=2.2.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+tomlkit = ">=0.10.1"
+typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+spelling = ["pyenchant (>=3.2,<4.0)"]
+testutils = ["gitpython (>3)"]
+
+[[package]]
+name = "pyparsing"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "dev"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pytest"
+version = "7.2.0"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-cov"
+version = "4.0.0"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "tomlkit"
+version = "0.11.5"
+description = "Style preserving TOML library"
+category = "dev"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[[package]]
+name = "typed-ast"
+version = "1.5.4"
+description = "a fork of Python 2 and 3 ast modules with type comment support"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "typing-extensions"
+version = "4.4.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "wrapt"
+version = "1.14.1"
+description = "Module for decorators, wrappers and monkey patching."
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "zipp"
+version = "3.10.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)"]
+testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.7.2"
+content-hash = "2d85a7c457c2793692572a27a7888bf3b7d8bab70651633749886dd13e4124af"
+
+[metadata.files]
+astroid = [
+    {file = "astroid-2.12.12-py3-none-any.whl", hash = "sha256:72702205200b2a638358369d90c222d74ebc376787af8fb2f7f2a86f7b5cc85f"},
+    {file = "astroid-2.12.12.tar.gz", hash = "sha256:1c00a14f5a3ed0339d38d2e2e5b74ea2591df5861c0936bb292b84ccf3a78d83"},
+]
+attrs = [
+    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
+    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
+]
+black = [
+    {file = "black-22.10.0-1fixedarch-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa"},
+    {file = "black-22.10.0-1fixedarch-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:5d8f74030e67087b219b032aa33a919fae8806d49c867846bfacde57f43972ef"},
+    {file = "black-22.10.0-1fixedarch-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:197df8509263b0b8614e1df1756b1dd41be6738eed2ba9e9769f3880c2b9d7b6"},
+    {file = "black-22.10.0-1fixedarch-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:2644b5d63633702bc2c5f3754b1b475378fbbfb481f62319388235d0cd104c2d"},
+    {file = "black-22.10.0-1fixedarch-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:e41a86c6c650bcecc6633ee3180d80a025db041a8e2398dcc059b3afa8382cd4"},
+    {file = "black-22.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2039230db3c6c639bd84efe3292ec7b06e9214a2992cd9beb293d639c6402edb"},
+    {file = "black-22.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7"},
+    {file = "black-22.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:819dc789f4498ecc91438a7de64427c73b45035e2e3680c92e18795a839ebb66"},
+    {file = "black-22.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5b9b29da4f564ba8787c119f37d174f2b69cdfdf9015b7d8c5c16121ddc054ae"},
+    {file = "black-22.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8b49776299fece66bffaafe357d929ca9451450f5466e997a7285ab0fe28e3b"},
+    {file = "black-22.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:21199526696b8f09c3997e2b4db8d0b108d801a348414264d2eb8eb2532e540d"},
+    {file = "black-22.10.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e464456d24e23d11fced2bc8c47ef66d471f845c7b7a42f3bd77bf3d1789650"},
+    {file = "black-22.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:9311e99228ae10023300ecac05be5a296f60d2fd10fff31cf5c1fa4ca4b1988d"},
+    {file = "black-22.10.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fba8a281e570adafb79f7755ac8721b6cf1bbf691186a287e990c7929c7692ff"},
+    {file = "black-22.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:915ace4ff03fdfff953962fa672d44be269deb2eaf88499a0f8805221bc68c87"},
+    {file = "black-22.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:444ebfb4e441254e87bad00c661fe32df9969b2bf224373a448d8aca2132b395"},
+    {file = "black-22.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:974308c58d057a651d182208a484ce80a26dac0caef2895836a92dd6ebd725e0"},
+    {file = "black-22.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72ef3925f30e12a184889aac03d77d031056860ccae8a1e519f6cbb742736383"},
+    {file = "black-22.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de"},
+    {file = "black-22.10.0-py3-none-any.whl", hash = "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458"},
+    {file = "black-22.10.0.tar.gz", hash = "sha256:f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1"},
+]
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+colorama = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+coverage = [
+    {file = "coverage-6.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef8674b0ee8cc11e2d574e3e2998aea5df5ab242e012286824ea3c6970580e53"},
+    {file = "coverage-6.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:784f53ebc9f3fd0e2a3f6a78b2be1bd1f5575d7863e10c6e12504f240fd06660"},
+    {file = "coverage-6.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4a5be1748d538a710f87542f22c2cad22f80545a847ad91ce45e77417293eb4"},
+    {file = "coverage-6.5.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83516205e254a0cb77d2d7bb3632ee019d93d9f4005de31dca0a8c3667d5bc04"},
+    {file = "coverage-6.5.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af4fffaffc4067232253715065e30c5a7ec6faac36f8fc8d6f64263b15f74db0"},
+    {file = "coverage-6.5.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:97117225cdd992a9c2a5515db1f66b59db634f59d0679ca1fa3fe8da32749cae"},
+    {file = "coverage-6.5.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:a1170fa54185845505fbfa672f1c1ab175446c887cce8212c44149581cf2d466"},
+    {file = "coverage-6.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:11b990d520ea75e7ee8dcab5bc908072aaada194a794db9f6d7d5cfd19661e5a"},
+    {file = "coverage-6.5.0-cp310-cp310-win32.whl", hash = "sha256:5dbec3b9095749390c09ab7c89d314727f18800060d8d24e87f01fb9cfb40b32"},
+    {file = "coverage-6.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:59f53f1dc5b656cafb1badd0feb428c1e7bc19b867479ff72f7a9dd9b479f10e"},
+    {file = "coverage-6.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4a5375e28c5191ac38cca59b38edd33ef4cc914732c916f2929029b4bfb50795"},
+    {file = "coverage-6.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4ed2820d919351f4167e52425e096af41bfabacb1857186c1ea32ff9983ed75"},
+    {file = "coverage-6.5.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:33a7da4376d5977fbf0a8ed91c4dffaaa8dbf0ddbf4c8eea500a2486d8bc4d7b"},
+    {file = "coverage-6.5.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8fb6cf131ac4070c9c5a3e21de0f7dc5a0fbe8bc77c9456ced896c12fcdad91"},
+    {file = "coverage-6.5.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a6b7d95969b8845250586f269e81e5dfdd8ff828ddeb8567a4a2eaa7313460c4"},
+    {file = "coverage-6.5.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:1ef221513e6f68b69ee9e159506d583d31aa3567e0ae84eaad9d6ec1107dddaa"},
+    {file = "coverage-6.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cca4435eebea7962a52bdb216dec27215d0df64cf27fc1dd538415f5d2b9da6b"},
+    {file = "coverage-6.5.0-cp311-cp311-win32.whl", hash = "sha256:98e8a10b7a314f454d9eff4216a9a94d143a7ee65018dd12442e898ee2310578"},
+    {file = "coverage-6.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:bc8ef5e043a2af066fa8cbfc6e708d58017024dc4345a1f9757b329a249f041b"},
+    {file = "coverage-6.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4433b90fae13f86fafff0b326453dd42fc9a639a0d9e4eec4d366436d1a41b6d"},
+    {file = "coverage-6.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4f05d88d9a80ad3cac6244d36dd89a3c00abc16371769f1340101d3cb899fc3"},
+    {file = "coverage-6.5.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:94e2565443291bd778421856bc975d351738963071e9b8839ca1fc08b42d4bef"},
+    {file = "coverage-6.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:027018943386e7b942fa832372ebc120155fd970837489896099f5cfa2890f79"},
+    {file = "coverage-6.5.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:255758a1e3b61db372ec2736c8e2a1fdfaf563977eedbdf131de003ca5779b7d"},
+    {file = "coverage-6.5.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:851cf4ff24062c6aec510a454b2584f6e998cada52d4cb58c5e233d07172e50c"},
+    {file = "coverage-6.5.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:12adf310e4aafddc58afdb04d686795f33f4d7a6fa67a7a9d4ce7d6ae24d949f"},
+    {file = "coverage-6.5.0-cp37-cp37m-win32.whl", hash = "sha256:b5604380f3415ba69de87a289a2b56687faa4fe04dbee0754bfcae433489316b"},
+    {file = "coverage-6.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:4a8dbc1f0fbb2ae3de73eb0bdbb914180c7abfbf258e90b311dcd4f585d44bd2"},
+    {file = "coverage-6.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d900bb429fdfd7f511f868cedd03a6bbb142f3f9118c09b99ef8dc9bf9643c3c"},
+    {file = "coverage-6.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2198ea6fc548de52adc826f62cb18554caedfb1d26548c1b7c88d8f7faa8f6ba"},
+    {file = "coverage-6.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c4459b3de97b75e3bd6b7d4b7f0db13f17f504f3d13e2a7c623786289dd670e"},
+    {file = "coverage-6.5.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:20c8ac5386253717e5ccc827caad43ed66fea0efe255727b1053a8154d952398"},
+    {file = "coverage-6.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b07130585d54fe8dff3d97b93b0e20290de974dc8177c320aeaf23459219c0b"},
+    {file = "coverage-6.5.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:dbdb91cd8c048c2b09eb17713b0c12a54fbd587d79adcebad543bc0cd9a3410b"},
+    {file = "coverage-6.5.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:de3001a203182842a4630e7b8d1a2c7c07ec1b45d3084a83d5d227a3806f530f"},
+    {file = "coverage-6.5.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e07f4a4a9b41583d6eabec04f8b68076ab3cd44c20bd29332c6572dda36f372e"},
+    {file = "coverage-6.5.0-cp38-cp38-win32.whl", hash = "sha256:6d4817234349a80dbf03640cec6109cd90cba068330703fa65ddf56b60223a6d"},
+    {file = "coverage-6.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:7ccf362abd726b0410bf8911c31fbf97f09f8f1061f8c1cf03dfc4b6372848f6"},
+    {file = "coverage-6.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:633713d70ad6bfc49b34ead4060531658dc6dfc9b3eb7d8a716d5873377ab745"},
+    {file = "coverage-6.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:95203854f974e07af96358c0b261f1048d8e1083f2de9b1c565e1be4a3a48cfc"},
+    {file = "coverage-6.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9023e237f4c02ff739581ef35969c3739445fb059b060ca51771e69101efffe"},
+    {file = "coverage-6.5.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:265de0fa6778d07de30bcf4d9dc471c3dc4314a23a3c6603d356a3c9abc2dfcf"},
+    {file = "coverage-6.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f830ed581b45b82451a40faabb89c84e1a998124ee4212d440e9c6cf70083e5"},
+    {file = "coverage-6.5.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:7b6be138d61e458e18d8e6ddcddd36dd96215edfe5f1168de0b1b32635839b62"},
+    {file = "coverage-6.5.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:42eafe6778551cf006a7c43153af1211c3aaab658d4d66fa5fcc021613d02518"},
+    {file = "coverage-6.5.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:723e8130d4ecc8f56e9a611e73b31219595baa3bb252d539206f7bbbab6ffc1f"},
+    {file = "coverage-6.5.0-cp39-cp39-win32.whl", hash = "sha256:d9ecf0829c6a62b9b573c7bb6d4dcd6ba8b6f80be9ba4fc7ed50bf4ac9aecd72"},
+    {file = "coverage-6.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:fc2af30ed0d5ae0b1abdb4ebdce598eafd5b35397d4d75deb341a614d333d987"},
+    {file = "coverage-6.5.0-pp36.pp37.pp38-none-any.whl", hash = "sha256:1431986dac3923c5945271f169f59c45b8802a114c8f548d611f2015133df77a"},
+    {file = "coverage-6.5.0.tar.gz", hash = "sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84"},
+]
+dill = [
+    {file = "dill-0.3.6-py3-none-any.whl", hash = "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0"},
+    {file = "dill-0.3.6.tar.gz", hash = "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"},
+]
+exceptiongroup = [
+    {file = "exceptiongroup-1.0.0rc9-py3-none-any.whl", hash = "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337"},
+    {file = "exceptiongroup-1.0.0rc9.tar.gz", hash = "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-5.0.0-py3-none-any.whl", hash = "sha256:ddb0e35065e8938f867ed4928d0ae5bf2a53b7773871bfe6bcc7e4fcdc7dea43"},
+    {file = "importlib_metadata-5.0.0.tar.gz", hash = "sha256:da31db32b304314d044d3c12c79bd59e307889b287ad12ff387b3500835fc2ab"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+isort = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
+]
+lazy-object-proxy = [
+    {file = "lazy-object-proxy-1.8.0.tar.gz", hash = "sha256:c219a00245af0f6fa4e95901ed28044544f50152840c5b6a3e7b2568db34d156"},
+    {file = "lazy_object_proxy-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4fd031589121ad46e293629b39604031d354043bb5cdf83da4e93c2d7f3389fe"},
+    {file = "lazy_object_proxy-1.8.0-cp310-cp310-win32.whl", hash = "sha256:b70d6e7a332eb0217e7872a73926ad4fdc14f846e85ad6749ad111084e76df25"},
+    {file = "lazy_object_proxy-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:eb329f8d8145379bf5dbe722182410fe8863d186e51bf034d2075eb8d85ee25b"},
+    {file = "lazy_object_proxy-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4e2d9f764f1befd8bdc97673261b8bb888764dfdbd7a4d8f55e4fbcabb8c3fb7"},
+    {file = "lazy_object_proxy-1.8.0-cp311-cp311-win32.whl", hash = "sha256:e20bfa6db17a39c706d24f82df8352488d2943a3b7ce7d4c22579cb89ca8896e"},
+    {file = "lazy_object_proxy-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:14010b49a2f56ec4943b6cf925f597b534ee2fe1f0738c84b3bce0c1a11ff10d"},
+    {file = "lazy_object_proxy-1.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6850e4aeca6d0df35bb06e05c8b934ff7c533734eb51d0ceb2d63696f1e6030c"},
+    {file = "lazy_object_proxy-1.8.0-cp37-cp37m-win32.whl", hash = "sha256:5b51d6f3bfeb289dfd4e95de2ecd464cd51982fe6f00e2be1d0bf94864d58acd"},
+    {file = "lazy_object_proxy-1.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:6f593f26c470a379cf7f5bc6db6b5f1722353e7bf937b8d0d0b3fba911998858"},
+    {file = "lazy_object_proxy-1.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0c1c7c0433154bb7c54185714c6929acc0ba04ee1b167314a779b9025517eada"},
+    {file = "lazy_object_proxy-1.8.0-cp38-cp38-win32.whl", hash = "sha256:d176f392dbbdaacccf15919c77f526edf11a34aece58b55ab58539807b85436f"},
+    {file = "lazy_object_proxy-1.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:afcaa24e48bb23b3be31e329deb3f1858f1f1df86aea3d70cb5c8578bfe5261c"},
+    {file = "lazy_object_proxy-1.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:71d9ae8a82203511a6f60ca5a1b9f8ad201cac0fc75038b2dc5fa519589c9288"},
+    {file = "lazy_object_proxy-1.8.0-cp39-cp39-win32.whl", hash = "sha256:8f6ce2118a90efa7f62dd38c7dbfffd42f468b180287b748626293bf12ed468f"},
+    {file = "lazy_object_proxy-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:eac3a9a5ef13b332c059772fd40b4b1c3d45a3a2b05e33a361dee48e54a4dad0"},
+    {file = "lazy_object_proxy-1.8.0-pp37-pypy37_pp73-any.whl", hash = "sha256:ae032743794fba4d171b5b67310d69176287b5bf82a21f588282406a79498891"},
+    {file = "lazy_object_proxy-1.8.0-pp38-pypy38_pp73-any.whl", hash = "sha256:7e1561626c49cb394268edd00501b289053a652ed762c58e1081224c8d881cec"},
+    {file = "lazy_object_proxy-1.8.0-pp39-pypy39_pp73-any.whl", hash = "sha256:ce58b2b3734c73e68f0e30e4e725264d4d6be95818ec0a0be4bb6bf9a7e79aa8"},
+]
+mccabe = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+mypy = [
+    {file = "mypy-0.982-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5085e6f442003fa915aeb0a46d4da58128da69325d8213b4b35cc7054090aed5"},
+    {file = "mypy-0.982-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:41fd1cf9bc0e1c19b9af13a6580ccb66c381a5ee2cf63ee5ebab747a4badeba3"},
+    {file = "mypy-0.982-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f793e3dd95e166b66d50e7b63e69e58e88643d80a3dcc3bcd81368e0478b089c"},
+    {file = "mypy-0.982-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86ebe67adf4d021b28c3f547da6aa2cce660b57f0432617af2cca932d4d378a6"},
+    {file = "mypy-0.982-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:175f292f649a3af7082fe36620369ffc4661a71005aa9f8297ea473df5772046"},
+    {file = "mypy-0.982-cp310-cp310-win_amd64.whl", hash = "sha256:8ee8c2472e96beb1045e9081de8e92f295b89ac10c4109afdf3a23ad6e644f3e"},
+    {file = "mypy-0.982-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:58f27ebafe726a8e5ccb58d896451dd9a662a511a3188ff6a8a6a919142ecc20"},
+    {file = "mypy-0.982-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d6af646bd46f10d53834a8e8983e130e47d8ab2d4b7a97363e35b24e1d588947"},
+    {file = "mypy-0.982-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e7aeaa763c7ab86d5b66ff27f68493d672e44c8099af636d433a7f3fa5596d40"},
+    {file = "mypy-0.982-cp37-cp37m-win_amd64.whl", hash = "sha256:724d36be56444f569c20a629d1d4ee0cb0ad666078d59bb84f8f887952511ca1"},
+    {file = "mypy-0.982-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:14d53cdd4cf93765aa747a7399f0961a365bcddf7855d9cef6306fa41de01c24"},
+    {file = "mypy-0.982-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:26ae64555d480ad4b32a267d10cab7aec92ff44de35a7cd95b2b7cb8e64ebe3e"},
+    {file = "mypy-0.982-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6389af3e204975d6658de4fb8ac16f58c14e1bacc6142fee86d1b5b26aa52bda"},
+    {file = "mypy-0.982-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b35ce03a289480d6544aac85fa3674f493f323d80ea7226410ed065cd46f206"},
+    {file = "mypy-0.982-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c6e564f035d25c99fd2b863e13049744d96bd1947e3d3d2f16f5828864506763"},
+    {file = "mypy-0.982-cp38-cp38-win_amd64.whl", hash = "sha256:cebca7fd333f90b61b3ef7f217ff75ce2e287482206ef4a8b18f32b49927b1a2"},
+    {file = "mypy-0.982-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:a705a93670c8b74769496280d2fe6cd59961506c64f329bb179970ff1d24f9f8"},
+    {file = "mypy-0.982-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:75838c649290d83a2b83a88288c1eb60fe7a05b36d46cbea9d22efc790002146"},
+    {file = "mypy-0.982-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:91781eff1f3f2607519c8b0e8518aad8498af1419e8442d5d0afb108059881fc"},
+    {file = "mypy-0.982-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaa97b9ddd1dd9901a22a879491dbb951b5dec75c3b90032e2baa7336777363b"},
+    {file = "mypy-0.982-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a692a8e7d07abe5f4b2dd32d731812a0175626a90a223d4b58f10f458747dd8a"},
+    {file = "mypy-0.982-cp39-cp39-win_amd64.whl", hash = "sha256:eb7a068e503be3543c4bd329c994103874fa543c1727ba5288393c21d912d795"},
+    {file = "mypy-0.982-py3-none-any.whl", hash = "sha256:1021c241e8b6e1ca5a47e4d52601274ac078a89845cfde66c6d5f769819ffa1d"},
+    {file = "mypy-0.982.tar.gz", hash = "sha256:85f7a343542dc8b1ed0a888cdd34dca56462654ef23aa673907305b260b3d746"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pathspec = [
+    {file = "pathspec-0.10.1-py3-none-any.whl", hash = "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93"},
+    {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
+]
+platformdirs = [
+    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
+    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+pylint = [
+    {file = "pylint-2.15.5-py3-none-any.whl", hash = "sha256:c2108037eb074334d9e874dc3c783752cc03d0796c88c9a9af282d0f161a1004"},
+    {file = "pylint-2.15.5.tar.gz", hash = "sha256:3b120505e5af1d06a5ad76b55d8660d44bf0f2fc3c59c2bdd94e39188ee3a4df"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+pytest = [
+    {file = "pytest-7.2.0-py3-none-any.whl", hash = "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71"},
+    {file = "pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
+]
+pytest-cov = [
+    {file = "pytest-cov-4.0.0.tar.gz", hash = "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"},
+    {file = "pytest_cov-4.0.0-py3-none-any.whl", hash = "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+tomlkit = [
+    {file = "tomlkit-0.11.5-py3-none-any.whl", hash = "sha256:f2ef9da9cef846ee027947dc99a45d6b68a63b0ebc21944649505bf2e8bc5fe7"},
+    {file = "tomlkit-0.11.5.tar.gz", hash = "sha256:571854ebbb5eac89abcb4a2e47d7ea27b89bf29e09c35395da6f03dd4ae23d1c"},
+]
+typed-ast = [
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe"},
+    {file = "typed_ast-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6"},
+    {file = "typed_ast-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
+    {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
+    {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+]
+wrapt = [
+    {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
+    {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
+    {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win32.whl", hash = "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win_amd64.whl", hash = "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00"},
+    {file = "wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win32.whl", hash = "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471"},
+    {file = "wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win32.whl", hash = "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57"},
+    {file = "wrapt-1.14.1-cp38-cp38-win32.whl", hash = "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5"},
+    {file = "wrapt-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe"},
+    {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
+    {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
+    {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
+]
+zipp = [
+    {file = "zipp-3.10.0-py3-none-any.whl", hash = "sha256:4fcb6f278987a6605757302a6e40e896257570d11c51628968ccb2a47e80c6c1"},
+    {file = "zipp-3.10.0.tar.gz", hash = "sha256:7a7262fd930bd3e36c50b9a64897aec3fafff3dfdeec9623ae22b40e93f99bb8"},
+]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "catppuccin"
+version = "1.0.0"
+description = "🐍 Soothing pastel theme for Python."
+authors = ["backwardspy <backwardspy@gmail.com>"]
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.7.2"
+
+[tool.poetry.group.dev.dependencies]
+pylint = "^2.15.5"
+mypy = "^0.982"
+black = "^22.10.0"
+isort = "^5.10.1"
+pytest = "^7.2.0"
+pytest-cov = "^4.0.0"
+
+[too.isort]
+profile = "black"

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,542 @@
+from typing import Dict
+
+import pytest
+
+ColourJSON = Dict[str, str]
+FlavourJSON = Dict[str, ColourJSON]
+PaletteJSON = Dict[str, FlavourJSON]
+
+
+@pytest.fixture
+def palette_json() -> PaletteJSON:
+    # from https://github.com/catppuccin/palette/blob/main/palette.json
+    return {
+        "latte": {
+            "rosewater": {
+                "hex": "#dc8a78",
+                "rgb": "rgb(220, 138, 120)",
+                "hsl": "hsl(11, 59%, 67%)",
+            },
+            "flamingo": {
+                "hex": "#dd7878",
+                "rgb": "rgb(221, 120, 120)",
+                "hsl": "hsl(0, 60%, 67%)",
+            },
+            "pink": {
+                "hex": "#ea76cb",
+                "rgb": "rgb(234, 118, 203)",
+                "hsl": "hsl(316, 73%, 69%)",
+            },
+            "mauve": {
+                "hex": "#8839ef",
+                "rgb": "rgb(136, 57, 239)",
+                "hsl": "hsl(266, 85%, 58%)",
+            },
+            "red": {
+                "hex": "#d20f39",
+                "rgb": "rgb(210, 15, 57)",
+                "hsl": "hsl(347, 87%, 44%)",
+            },
+            "maroon": {
+                "hex": "#e64553",
+                "rgb": "rgb(230, 69, 83)",
+                "hsl": "hsl(355, 76%, 59%)",
+            },
+            "peach": {
+                "hex": "#fe640b",
+                "rgb": "rgb(254, 100, 11)",
+                "hsl": "hsl(22, 99%, 52%)",
+            },
+            "yellow": {
+                "hex": "#df8e1d",
+                "rgb": "rgb(223, 142, 29)",
+                "hsl": "hsl(35, 77%, 49%)",
+            },
+            "green": {
+                "hex": "#40a02b",
+                "rgb": "rgb(64, 160, 43)",
+                "hsl": "hsl(109, 58%, 40%)",
+            },
+            "teal": {
+                "hex": "#179299",
+                "rgb": "rgb(23, 146, 153)",
+                "hsl": "hsl(183, 74%, 35%)",
+            },
+            "sky": {
+                "hex": "#04a5e5",
+                "rgb": "rgb(4, 165, 229)",
+                "hsl": "hsl(197, 97%, 46%)",
+            },
+            "sapphire": {
+                "hex": "#209fb5",
+                "rgb": "rgb(32, 159, 181)",
+                "hsl": "hsl(189, 70%, 42%)",
+            },
+            "blue": {
+                "hex": "#1e66f5",
+                "rgb": "rgb(30, 102, 245)",
+                "hsl": "hsl(220, 91%, 54%)",
+            },
+            "lavender": {
+                "hex": "#7287fd",
+                "rgb": "rgb(114, 135, 253)",
+                "hsl": "hsl(231, 97%, 72%)",
+            },
+            "text": {
+                "hex": "#4c4f69",
+                "rgb": "rgb(76, 79, 105)",
+                "hsl": "hsl(234, 16%, 35%)",
+            },
+            "subtext1": {
+                "hex": "#5c5f77",
+                "rgb": "rgb(92, 95, 119)",
+                "hsl": "hsl(233, 13%, 41%)",
+            },
+            "subtext0": {
+                "hex": "#6c6f85",
+                "rgb": "rgb(108, 111, 133)",
+                "hsl": "hsl(233, 10%, 47%)",
+            },
+            "overlay2": {
+                "hex": "#7c7f93",
+                "rgb": "rgb(124, 127, 147)",
+                "hsl": "hsl(232, 10%, 53%)",
+            },
+            "overlay1": {
+                "hex": "#8c8fa1",
+                "rgb": "rgb(140, 143, 161)",
+                "hsl": "hsl(231, 10%, 59%)",
+            },
+            "overlay0": {
+                "hex": "#9ca0b0",
+                "rgb": "rgb(156, 160, 176)",
+                "hsl": "hsl(228, 11%, 65%)",
+            },
+            "surface2": {
+                "hex": "#acb0be",
+                "rgb": "rgb(172, 176, 190)",
+                "hsl": "hsl(227, 12%, 71%)",
+            },
+            "surface1": {
+                "hex": "#bcc0cc",
+                "rgb": "rgb(188, 192, 204)",
+                "hsl": "hsl(225, 14%, 77%)",
+            },
+            "surface0": {
+                "hex": "#ccd0da",
+                "rgb": "rgb(204, 208, 218)",
+                "hsl": "hsl(223, 16%, 83%)",
+            },
+            "base": {
+                "hex": "#eff1f5",
+                "rgb": "rgb(239, 241, 245)",
+                "hsl": "hsl(220, 23%, 95%)",
+            },
+            "mantle": {
+                "hex": "#e6e9ef",
+                "rgb": "rgb(230, 233, 239)",
+                "hsl": "hsl(220, 22%, 92%)",
+            },
+            "crust": {
+                "hex": "#dce0e8",
+                "rgb": "rgb(220, 224, 232)",
+                "hsl": "hsl(220, 21%, 89%)",
+            },
+        },
+        "frappe": {
+            "rosewater": {
+                "hex": "#f2d5cf",
+                "rgb": "rgb(242, 213, 207)",
+                "hsl": "hsl(10, 57%, 88%)",
+            },
+            "flamingo": {
+                "hex": "#eebebe",
+                "rgb": "rgb(238, 190, 190)",
+                "hsl": "hsl(0, 59%, 84%)",
+            },
+            "pink": {
+                "hex": "#f4b8e4",
+                "rgb": "rgb(244, 184, 228)",
+                "hsl": "hsl(316, 73%, 84%)",
+            },
+            "mauve": {
+                "hex": "#ca9ee6",
+                "rgb": "rgb(202, 158, 230)",
+                "hsl": "hsl(277, 59%, 76%)",
+            },
+            "red": {
+                "hex": "#e78284",
+                "rgb": "rgb(231, 130, 132)",
+                "hsl": "hsl(359, 68%, 71%)",
+            },
+            "maroon": {
+                "hex": "#ea999c",
+                "rgb": "rgb(234, 153, 156)",
+                "hsl": "hsl(358, 66%, 76%)",
+            },
+            "peach": {
+                "hex": "#ef9f76",
+                "rgb": "rgb(239, 159, 118)",
+                "hsl": "hsl(20, 79%, 70%)",
+            },
+            "yellow": {
+                "hex": "#e5c890",
+                "rgb": "rgb(229, 200, 144)",
+                "hsl": "hsl(40, 62%, 73%)",
+            },
+            "green": {
+                "hex": "#a6d189",
+                "rgb": "rgb(166, 209, 137)",
+                "hsl": "hsl(96, 44%, 68%)",
+            },
+            "teal": {
+                "hex": "#81c8be",
+                "rgb": "rgb(129, 200, 190)",
+                "hsl": "hsl(172, 39%, 65%)",
+            },
+            "sky": {
+                "hex": "#99d1db",
+                "rgb": "rgb(153, 209, 219)",
+                "hsl": "hsl(189, 48%, 73%)",
+            },
+            "sapphire": {
+                "hex": "#85c1dc",
+                "rgb": "rgb(133, 193, 220)",
+                "hsl": "hsl(199, 55%, 69%)",
+            },
+            "blue": {
+                "hex": "#8caaee",
+                "rgb": "rgb(140, 170, 238)",
+                "hsl": "hsl(222, 74%, 74%)",
+            },
+            "lavender": {
+                "hex": "#babbf1",
+                "rgb": "rgb(186, 187, 241)",
+                "hsl": "hsl(239, 66%, 84%)",
+            },
+            "text": {
+                "hex": "#c6d0f5",
+                "rgb": "rgb(198, 208, 245)",
+                "hsl": "hsl(227, 70%, 87%)",
+            },
+            "subtext1": {
+                "hex": "#b5bfe2",
+                "rgb": "rgb(181, 191, 226)",
+                "hsl": "hsl(227, 44%, 80%)",
+            },
+            "subtext0": {
+                "hex": "#a5adce",
+                "rgb": "rgb(165, 173, 206)",
+                "hsl": "hsl(228, 29%, 73%)",
+            },
+            "overlay2": {
+                "hex": "#949cbb",
+                "rgb": "rgb(148, 156, 187)",
+                "hsl": "hsl(228, 22%, 66%)",
+            },
+            "overlay1": {
+                "hex": "#838ba7",
+                "rgb": "rgb(131, 139, 167)",
+                "hsl": "hsl(227, 17%, 58%)",
+            },
+            "overlay0": {
+                "hex": "#737994",
+                "rgb": "rgb(115, 121, 148)",
+                "hsl": "hsl(229, 13%, 52%)",
+            },
+            "surface2": {
+                "hex": "#626880",
+                "rgb": "rgb(98, 104, 128)",
+                "hsl": "hsl(228, 13%, 44%)",
+            },
+            "surface1": {
+                "hex": "#51576d",
+                "rgb": "rgb(81, 87, 109)",
+                "hsl": "hsl(227, 15%, 37%)",
+            },
+            "surface0": {
+                "hex": "#414559",
+                "rgb": "rgb(65, 69, 89)",
+                "hsl": "hsl(230, 16%, 30%)",
+            },
+            "base": {
+                "hex": "#303446",
+                "rgb": "rgb(48, 52, 70)",
+                "hsl": "hsl(229, 19%, 23%)",
+            },
+            "mantle": {
+                "hex": "#292c3c",
+                "rgb": "rgb(41, 44, 60)",
+                "hsl": "hsl(231, 19%, 20%)",
+            },
+            "crust": {
+                "hex": "#232634",
+                "rgb": "rgb(35, 38, 52)",
+                "hsl": "hsl(229, 20%, 17%)",
+            },
+        },
+        "macchiato": {
+            "rosewater": {
+                "hex": "#f4dbd6",
+                "rgb": "rgb(244, 219, 214)",
+                "hsl": "hsl(10, 58%, 90%)",
+            },
+            "flamingo": {
+                "hex": "#f0c6c6",
+                "rgb": "rgb(240, 198, 198)",
+                "hsl": "hsl(0, 58%, 86%)",
+            },
+            "pink": {
+                "hex": "#f5bde6",
+                "rgb": "rgb(245, 189, 230)",
+                "hsl": "hsl(316, 74%, 85%)",
+            },
+            "mauve": {
+                "hex": "#c6a0f6",
+                "rgb": "rgb(198, 160, 246)",
+                "hsl": "hsl(267, 83%, 80%)",
+            },
+            "red": {
+                "hex": "#ed8796",
+                "rgb": "rgb(237, 135, 150)",
+                "hsl": "hsl(351, 74%, 73%)",
+            },
+            "maroon": {
+                "hex": "#ee99a0",
+                "rgb": "rgb(238, 153, 160)",
+                "hsl": "hsl(355, 71%, 77%)",
+            },
+            "peach": {
+                "hex": "#f5a97f",
+                "rgb": "rgb(245, 169, 127)",
+                "hsl": "hsl(21, 86%, 73%)",
+            },
+            "yellow": {
+                "hex": "#eed49f",
+                "rgb": "rgb(238, 212, 159)",
+                "hsl": "hsl(40, 70%, 78%)",
+            },
+            "green": {
+                "hex": "#a6da95",
+                "rgb": "rgb(166, 218, 149)",
+                "hsl": "hsl(105, 48%, 72%)",
+            },
+            "teal": {
+                "hex": "#8bd5ca",
+                "rgb": "rgb(139, 213, 202)",
+                "hsl": "hsl(171, 47%, 69%)",
+            },
+            "sky": {
+                "hex": "#91d7e3",
+                "rgb": "rgb(145, 215, 227)",
+                "hsl": "hsl(189, 59%, 73%)",
+            },
+            "sapphire": {
+                "hex": "#7dc4e4",
+                "rgb": "rgb(125, 196, 228)",
+                "hsl": "hsl(199, 66%, 69%)",
+            },
+            "blue": {
+                "hex": "#8aadf4",
+                "rgb": "rgb(138, 173, 244)",
+                "hsl": "hsl(220, 83%, 75%)",
+            },
+            "lavender": {
+                "hex": "#b7bdf8",
+                "rgb": "rgb(183, 189, 248)",
+                "hsl": "hsl(234, 82%, 85%)",
+            },
+            "text": {
+                "hex": "#cad3f5",
+                "rgb": "rgb(202, 211, 245)",
+                "hsl": "hsl(227, 68%, 88%)",
+            },
+            "subtext1": {
+                "hex": "#b8c0e0",
+                "rgb": "rgb(184, 192, 224)",
+                "hsl": "hsl(228, 39%, 80%)",
+            },
+            "subtext0": {
+                "hex": "#a5adcb",
+                "rgb": "rgb(165, 173, 203)",
+                "hsl": "hsl(227, 27%, 72%)",
+            },
+            "overlay2": {
+                "hex": "#939ab7",
+                "rgb": "rgb(147, 154, 183)",
+                "hsl": "hsl(228, 20%, 65%)",
+            },
+            "overlay1": {
+                "hex": "#8087a2",
+                "rgb": "rgb(128, 135, 162)",
+                "hsl": "hsl(228, 15%, 57%)",
+            },
+            "overlay0": {
+                "hex": "#6e738d",
+                "rgb": "rgb(110, 115, 141)",
+                "hsl": "hsl(230, 12%, 49%)",
+            },
+            "surface2": {
+                "hex": "#5b6078",
+                "rgb": "rgb(91, 96, 120)",
+                "hsl": "hsl(230, 14%, 41%)",
+            },
+            "surface1": {
+                "hex": "#494d64",
+                "rgb": "rgb(73, 77, 100)",
+                "hsl": "hsl(231, 16%, 34%)",
+            },
+            "surface0": {
+                "hex": "#363a4f",
+                "rgb": "rgb(54, 58, 79)",
+                "hsl": "hsl(230, 19%, 26%)",
+            },
+            "base": {
+                "hex": "#24273a",
+                "rgb": "rgb(36, 39, 58)",
+                "hsl": "hsl(232, 23%, 18%)",
+            },
+            "mantle": {
+                "hex": "#1e2030",
+                "rgb": "rgb(30, 32, 48)",
+                "hsl": "hsl(233, 23%, 15%)",
+            },
+            "crust": {
+                "hex": "#181926",
+                "rgb": "rgb(24, 25, 38)",
+                "hsl": "hsl(236, 23%, 12%)",
+            },
+        },
+        "mocha": {
+            "rosewater": {
+                "hex": "#f5e0dc",
+                "rgb": "rgb(245, 224, 220)",
+                "hsl": "hsl(10, 56%, 91%)",
+            },
+            "flamingo": {
+                "hex": "#f2cdcd",
+                "rgb": "rgb(242, 205, 205)",
+                "hsl": "hsl(0, 59%, 88%)",
+            },
+            "pink": {
+                "hex": "#f5c2e7",
+                "rgb": "rgb(245, 194, 231)",
+                "hsl": "hsl(316, 72%, 86%)",
+            },
+            "mauve": {
+                "hex": "#cba6f7",
+                "rgb": "rgb(203, 166, 247)",
+                "hsl": "hsl(267, 84%, 81%)",
+            },
+            "red": {
+                "hex": "#f38ba8",
+                "rgb": "rgb(243, 139, 168)",
+                "hsl": "hsl(343, 81%, 75%)",
+            },
+            "maroon": {
+                "hex": "#eba0ac",
+                "rgb": "rgb(235, 160, 172)",
+                "hsl": "hsl(350, 65%, 77%)",
+            },
+            "peach": {
+                "hex": "#fab387",
+                "rgb": "rgb(250, 179, 135)",
+                "hsl": "hsl(23, 92%, 75%)",
+            },
+            "yellow": {
+                "hex": "#f9e2af",
+                "rgb": "rgb(249, 226, 175)",
+                "hsl": "hsl(41, 86%, 83%)",
+            },
+            "green": {
+                "hex": "#a6e3a1",
+                "rgb": "rgb(166, 227, 161)",
+                "hsl": "hsl(115, 54%, 76%)",
+            },
+            "teal": {
+                "hex": "#94e2d5",
+                "rgb": "rgb(148, 226, 213)",
+                "hsl": "hsl(170, 57%, 73%)",
+            },
+            "sky": {
+                "hex": "#89dceb",
+                "rgb": "rgb(137, 220, 235)",
+                "hsl": "hsl(189, 71%, 73%)",
+            },
+            "sapphire": {
+                "hex": "#74c7ec",
+                "rgb": "rgb(116, 199, 236)",
+                "hsl": "hsl(199, 76%, 69%)",
+            },
+            "blue": {
+                "hex": "#89b4fa",
+                "rgb": "rgb(137, 180, 250)",
+                "hsl": "hsl(217, 92%, 76%)",
+            },
+            "lavender": {
+                "hex": "#b4befe",
+                "rgb": "rgb(180, 190, 254)",
+                "hsl": "hsl(232, 97%, 85%)",
+            },
+            "text": {
+                "hex": "#cdd6f4",
+                "rgb": "rgb(205, 214, 244)",
+                "hsl": "hsl(226, 64%, 88%)",
+            },
+            "subtext1": {
+                "hex": "#bac2de",
+                "rgb": "rgb(186, 194, 222)",
+                "hsl": "hsl(227, 35%, 80%)",
+            },
+            "subtext0": {
+                "hex": "#a6adc8",
+                "rgb": "rgb(166, 173, 200)",
+                "hsl": "hsl(228, 24%, 72%)",
+            },
+            "overlay2": {
+                "hex": "#9399b2",
+                "rgb": "rgb(147, 153, 178)",
+                "hsl": "hsl(228, 17%, 64%)",
+            },
+            "overlay1": {
+                "hex": "#7f849c",
+                "rgb": "rgb(127, 132, 156)",
+                "hsl": "hsl(230, 13%, 55%)",
+            },
+            "overlay0": {
+                "hex": "#6c7086",
+                "rgb": "rgb(108, 112, 134)",
+                "hsl": "hsl(231, 11%, 47%)",
+            },
+            "surface2": {
+                "hex": "#585b70",
+                "rgb": "rgb(88, 91, 112)",
+                "hsl": "hsl(233, 12%, 39%)",
+            },
+            "surface1": {
+                "hex": "#45475a",
+                "rgb": "rgb(69, 71, 90)",
+                "hsl": "hsl(234, 13%, 31%)",
+            },
+            "surface0": {
+                "hex": "#313244",
+                "rgb": "rgb(49, 50, 68)",
+                "hsl": "hsl(237, 16%, 23%)",
+            },
+            "base": {
+                "hex": "#1e1e2e",
+                "rgb": "rgb(30, 30, 46)",
+                "hsl": "hsl(240, 21%, 15%)",
+            },
+            "mantle": {
+                "hex": "#181825",
+                "rgb": "rgb(24, 24, 37)",
+                "hsl": "hsl(240, 21%, 12%)",
+            },
+            "crust": {
+                "hex": "#11111b",
+                "rgb": "rgb(17, 17, 27)",
+                "hsl": "hsl(240, 23%, 9%)",
+            },
+        },
+    }

--- a/python/tests/test_colour.py
+++ b/python/tests/test_colour.py
@@ -1,0 +1,9 @@
+from catppuccin import Colour
+
+
+def test_colour_to_rgb():
+    assert Colour(12, 123, 234).rgb == (12, 123, 234)
+
+
+def test_colour_to_hex():
+    assert Colour(0x12, 0xEB, 0x77).hex == "12eb77"

--- a/python/tests/test_flavour.py
+++ b/python/tests/test_flavour.py
@@ -1,0 +1,27 @@
+from typing import cast
+
+from catppuccin import Flavour
+
+from .conftest import ColourJSON, FlavourJSON, PaletteJSON
+
+
+def validate_flavour(flavour: Flavour, flavour_json: FlavourJSON) -> None:
+    for colour_name, colour_json in flavour_json.items():
+        colour = getattr(flavour, colour_name)
+        assert f"#{colour.hex}" == cast(ColourJSON, colour_json)["hex"], colour_name
+
+
+def test_latte(palette_json: PaletteJSON) -> None:
+    validate_flavour(Flavour.latte(), palette_json["latte"])
+
+
+def test_frappe(palette_json: PaletteJSON) -> None:
+    validate_flavour(Flavour.frappe(), palette_json["frappe"])
+
+
+def test_macchiato(palette_json: PaletteJSON) -> None:
+    validate_flavour(Flavour.macchiato(), palette_json["macchiato"])
+
+
+def test_mocha(palette_json: PaletteJSON) -> None:
+    validate_flavour(Flavour.mocha(), palette_json["mocha"])


### PR DESCRIPTION
this python package exposes the catppuccin palette with just enough default features to be useful. you can pick colours from the four flavours, convert those colours to a hex string or their r/g/b components, and iterate over the flavours to get the full palette.

the project is managed by [poetry](https://python-poetry.org) and supports python >= 3.7.2.

future PRs will cover integration with third-party packages such as pygments and pygame. these will be gated behind optional package feature switches as with the rust crate. these integrations will also allow us to put some more flashy examples in the readme.