### PR TITLE
Rust: Add methods to `Flavour` to get each colour

### DIFF
--- a/rust/src/colour.rs
+++ b/rust/src/colour.rs
@@ -13,7 +13,7 @@ impl Colour {
     /// ```
     /// use catppuccin::Flavour;
     ///
-    /// let hex = Flavour::Mocha.colours().teal.hex();
+    /// let hex = Flavour::Mocha.teal().hex();
     /// assert_eq!(hex, "94E2D5");
     /// ```
     pub fn hex(&self) -> String {

--- a/rust/src/flavour.rs
+++ b/rust/src/flavour.rs
@@ -8,6 +8,21 @@ pub enum Flavour {
     Mocha,
 }
 
+macro_rules! impl_colour_method {
+    ($x:ident) => (
+        pub fn $x(self) -> $crate::Colour {
+            self.colours().$x
+        }
+    );
+    ($x:ident, $($y:ident),+ $(,)?) => (
+        pub fn $x(self) -> $crate::Colour {
+            self.colours().$x
+        }
+
+        impl_colour_method!($($y),+);
+    );
+}
+
 impl Flavour {
     pub fn name(self) -> &'static str {
         match self {
@@ -17,6 +32,12 @@ impl Flavour {
             Self::Mocha => "mocha",
         }
     }
+
+    impl_colour_method!(
+        rosewater, flamingo, pink, mauve, red, maroon, peach, yellow, green, teal, sky, sapphire,
+        blue, lavender, text, subtext1, subtext0, overlay2, overlay1, overlay0, surface2, surface1,
+        surface0, base, mantle, crust,
+    );
 
     pub fn colours(self) -> FlavourColours {
         match self {

--- a/rust/src/flavour.rs
+++ b/rust/src/flavour.rs
@@ -167,6 +167,38 @@ mod tests {
     use indoc::indoc;
 
     #[test]
+    fn verify_colour_methods() {
+        // We only need to test one flavour, as we just need to make sure the methods exists
+        // Because if the correct method exists it is guaurenteed to access to correctly named field
+        let _rosewater = Flavour::Latte.rosewater();
+        let _flamingo = Flavour::Latte.flamingo();
+        let _pink = Flavour::Latte.pink();
+        let _mauve = Flavour::Latte.mauve();
+        let _red = Flavour::Latte.red();
+        let _maroon = Flavour::Latte.maroon();
+        let _peach = Flavour::Latte.peach();
+        let _yellow = Flavour::Latte.yellow();
+        let _green = Flavour::Latte.green();
+        let _teal = Flavour::Latte.teal();
+        let _sky = Flavour::Latte.sky();
+        let _sapphire = Flavour::Latte.sapphire();
+        let _blue = Flavour::Latte.blue();
+        let _lavender = Flavour::Latte.lavender();
+        let _text = Flavour::Latte.text();
+        let _subtext1 = Flavour::Latte.subtext1();
+        let _subtext0 = Flavour::Latte.subtext0();
+        let _overlay2 = Flavour::Latte.overlay2();
+        let _overlay1 = Flavour::Latte.overlay1();
+        let _overlay0 = Flavour::Latte.overlay0();
+        let _surface2 = Flavour::Latte.surface2();
+        let _surface1 = Flavour::Latte.surface1();
+        let _surface0 = Flavour::Latte.surface0();
+        let _base = Flavour::Latte.base();
+        let _mantle = Flavour::Latte.mantle();
+        let _crust = Flavour::Latte.crust();
+    }
+
+    #[test]
     fn validate_latte_colours() {
         validate_colours(
             Flavour::Latte.colours(),

--- a/rust/src/flavour.rs
+++ b/rust/src/flavour.rs
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn verify_colour_methods() {
         // We only need to test one flavour, as we just need to make sure the methods exists
-        // Because if the correct method exists it is guaurenteed to access to correctly named field
+        // Because if the correct method exists it is guaranteed to access to the correctly named field
         let _rosewater = Flavour::Latte.rosewater();
         let _flamingo = Flavour::Latte.flamingo();
         let _pink = Flavour::Latte.pink();

--- a/rust/src/flavour.rs
+++ b/rust/src/flavour.rs
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn verify_colour_methods() {
         // We only need to test one flavour, as we just need to make sure the methods exists
-        // Because if the correct method exists it is guaranteed to access to the correctly named field
+        // Because if the correct method exists, it is guaranteed access to the correctly named field
         let _rosewater = Flavour::Latte.rosewater();
         let _flamingo = Flavour::Latte.flamingo();
         let _pink = Flavour::Latte.pink();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -22,7 +22,7 @@
 //! fn confirm(text: String) -> Button {
 //!     Button {
 //!         text,
-//!         background_colour: Flavour::Mocha.colours().green.hex(),
+//!         background_colour: Flavour::Mocha.green().hex(),
 //!     }
 //! }
 //! ```


### PR DESCRIPTION
This adds method to get each of the colors directly from the `Flavour` variants like so
```rust
Flavour::Latte.teal()
```
rather than needing to go through the `FlavourColours` struct

This closes #27