### PR TITLE
fix: expose scss files in package.json 'exports'

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
       "require": "./dist/index.cjs",
       "import": "./dist/index.mjs"
     },
-    "./style": "./css/catppuccin.css"
+    "./style": "./css/catppuccin.css",
+    "./scss/*": "./scss/*"
   },
   "scripts": {
     "test": "ava",


### PR DESCRIPTION
Some build systems (e.g. Webpack with sass-loader) use the `exports` key in package.json when looking for .scss files, which kept things like:
```scss
@use "@catppuccin/palette/scss/catppuccin";
```
from being able to find the files. This adds those files to `exports` so they can be resolved properly.