### PR TITLE
feat: create nix flake and palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     - [Node Package](#node-package)
     - [CSS](#css)
     - [Sass](#sass)
+    - [Nix](#nix-flake)
     - [Tailwind CSS](https://github.com/catppuccin/tailwindcss) (separate repository)
     - [Rust](https://github.com/catppuccin/rust) (separate repository)
     - [Python](https://github.com/catppuccin/python) (separate repository)
@@ -130,6 +131,21 @@ cp -r clr/* ~/Library/Colors
 2. Open the `sip/` folder
 3. Open the `.palette` files, and Sip will import the palettes
 
+### Nix Flake
+
+1. Add "github:catppuccin/palette" to your flake inputs
+2. Use the attributes described below
+
+#### Flake Outputs
+
+- `flavours :: [string]`: A list of the Catppuccin flavours
+- `accents :: [string]`: A list of all of Catppuccin's accent colours
+- `colours :: [string]`: A list of all of Catppuccin's colours
+- `${flavour}.${colour}.hex :: string`: The hex code for a given flavour and colour
+- `${flavour}.${colour}.red :: int`: The red RGB value for a given flavour and colour
+- `${flavour}.${colour}.green :: int`: The green RGB value for a given flavour and colour
+- `${flavour}.${colour}.blue :: int`: The blue RGB value for a given flavour and colour
+
 ## 💝 Thanks to
 
 - [Gingeh](https://github.com/gingeh)
@@ -137,6 +153,7 @@ cp -r clr/* ~/Library/Colors
 - [Andreas Grafen](https://github.com/andreasgrafen)
 - [Pocco81](https://github.com/Pocco81)
 - [winston](https://github.com/nekowinston)
+- [Stonks3141](https://github.com/Stonks3141)
 
 &nbsp;
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,4 @@
+{
+  description = "Soothing pastel theme to use within your projects!";
+  outputs = { self }: import ./nix;
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,37 @@
+rec {
+  flavours = [ "latte" "frappe" "macchiato" "mocha" ];
+  accents = [
+    "rosewater"
+    "flamingo"
+    "pink"
+    "mauve"
+    "red"
+    "maroon"
+    "peach"
+    "yellow"
+    "green"
+    "teal"
+    "sky"
+    "sapphire"
+    "blue"
+    "lavender"
+  ];
+  colours = accents ++ [
+    "text"
+    "subtext1"
+    "subtext0"
+    "overlay2"
+    "overlay1"
+    "overlay0"
+    "surface2"
+    "surface1"
+    "surface0"
+    "base"
+    "mantle"
+    "crust"
+  ];
+  latte = import ./latte.nix;
+  frappe = import ./frappe.nix;
+  macchiato = import ./macchiato.nix;
+  mocha = import ./mocha.nix;
+}

--- a/nix/frappe.nix
+++ b/nix/frappe.nix
@@ -1,0 +1,158 @@
+{
+  rosewater = {
+    hex = "f2d5cf";
+    red = 242;
+    green = 213;
+    blue = 207;
+  };
+  flamingo = {
+    hex = "eebebe";
+    red = 238;
+    green = 190;
+    blue = 190;
+  };
+  pink = {
+    hex = "f4b8e4";
+    red = 244;
+    green = 184;
+    blue = 228;
+  };
+  mauve = {
+    hex = "ca9ee6";
+    red = 202;
+    green = 158;
+    blue = 230;
+  };
+  red = {
+    hex = "e78284";
+    red = 231;
+    green = 130;
+    blue = 132;
+  };
+  maroon = {
+    hex = "ea999c";
+    red = 234;
+    green = 153;
+    blue = 156;
+  };
+  peach = {
+    hex = "ef9f76";
+    red = 239;
+    green = 159;
+    blue = 118;
+  };
+  yellow = {
+    hex = "e5c890";
+    red = 229;
+    green = 200;
+    blue = 144;
+  };
+  green = {
+    hex = "a6d189";
+    red = 166;
+    green = 209;
+    blue = 137;
+  };
+  teal = {
+    hex = "81c8be";
+    red = 129;
+    green = 200;
+    blue = 190;
+  };
+  sky = {
+    hex = "99d1db";
+    red = 153;
+    green = 209;
+    blue = 219;
+  };
+  sapphire = {
+    hex = "85c1dc";
+    red = 133;
+    green = 193;
+    blue = 220;
+  };
+  blue = {
+    hex = "8caaee";
+    red = 140;
+    green = 170;
+    blue = 238;
+  };
+  lavender = {
+    hex = "babbf1";
+    red = 186;
+    green = 187;
+    blue = 241;
+  };
+  text = {
+    hex = "c6d0f5";
+    red = 198;
+    green = 208;
+    blue = 245;
+  };
+  subtext1 = {
+    hex = "b5bfe2";
+    red = 181;
+    green = 191;
+    blue = 226;
+  };
+  subtext0 = {
+    hex = "a5adce";
+    red = 165;
+    green = 173;
+    blue = 206;
+  };
+  overlay2 = {
+    hex = "949cbb";
+    red = 148;
+    green = 156;
+    blue = 187;
+  };
+  overlay1 = {
+    hex = "838ba7";
+    red = 131;
+    green = 139;
+    blue = 167;
+  };
+  overlay0 = {
+    hex = "737994";
+    red = 115;
+    green = 121;
+    blue = 148;
+  };
+  surface2 = {
+    hex = "626880";
+    red = 98;
+    green = 104;
+    blue = 128;
+  };
+  surface1 = {
+    hex = "51576d";
+    red = 81;
+    green = 87;
+    blue = 109;
+  };
+  surface0 = {
+    hex = "414559";
+    red = 65;
+    green = 69;
+    blue = 89;
+  };
+  base = {
+    hex = "303446";
+    red = 48;
+    green = 52;
+    blue = 70;
+  };
+  mantle = {
+    hex = "292c3c";
+    red = 41;
+    green = 44;
+    blue = 60;
+  };
+  crust = {
+    hex = "232634";
+    red = 35;
+    green = 38;
+    blue = 52;
+  };
+}

--- a/nix/latte.nix
+++ b/nix/latte.nix
@@ -1,0 +1,158 @@
+{
+  rosewater = {
+    hex = "dc8a78";
+    red = 220;
+    blue = 138;
+    green = 120;
+  };
+  flamingo = {
+    hex = "dd7878";
+    red = 221;
+    blue = 120;
+    green = 120;
+  };
+  pink = {
+    hex = "ea76cb";
+    red = 234;
+    blue = 118;
+    green = 203;
+  };
+  mauve = {
+    hex = "8839ef";
+    red = 136;
+    blue = 57;
+    green = 239;
+  };
+  red = {
+    hex = "d20f39";
+    red = 210;
+    blue = 15;
+    green = 57;
+  };
+  maroon = {
+    hex = "e64553";
+    red = 230;
+    blue = 69;
+    green = 83;
+  };
+  peach = {
+    hex = "fe640b";
+    red = 254;
+    blue = 100;
+    green = 11;
+  };
+  yellow = {
+    hex = "df8e1d";
+    red = 223;
+    blue = 142;
+    green = 29;
+  };
+  green = {
+    hex = "40a02b";
+    red = 64;
+    blue = 160;
+    green = 43;
+  };
+  teal = {
+    hex = "179299";
+    red = 23;
+    blue = 146;
+    green = 153;
+  };
+  sky = {
+    hex = "04a5e5";
+    red = 4;
+    blue = 165;
+    green = 229;
+  };
+  sapphire = {
+    hex = "209fb5";
+    red = 32;
+    blue = 159;
+    green = 181;
+  };
+  blue = {
+    hex = "1e66f5";
+    red = 30;
+    blue = 102;
+    green = 245;
+  };
+  lavender = {
+    hex = "7287fd";
+    red = 114;
+    blue = 135;
+    green = 253;
+  };
+  text = {
+    hex = "4c4f69";
+    red = 76;
+    blue = 79;
+    green = 105;
+  };
+  subtext1 = {
+    hex = "5c5f77";
+    red = 92;
+    blue = 95;
+    green = 119;
+  };
+  subtext0 = {
+    hex = "6c6f85";
+    red = 108;
+    blue = 111;
+    green = 133;
+  };
+  overlay2 = {
+    hex = "7c7f93";
+    red = 124;
+    blue = 127;
+    green = 147;
+  };
+  overlay1 = {
+    hex = "8c8fa1";
+    red = 140;
+    blue = 143;
+    green = 161;
+  };
+  overlay0 = {
+    hex = "9ca0b0";
+    red = 156;
+    blue = 160;
+    green = 176;
+  };
+  surface2 = {
+    hex = "acb0be";
+    red = 172;
+    blue = 176;
+    green = 190;
+  };
+  surface1 = {
+    hex = "bcc0cc";
+    red = 188;
+    blue = 192;
+    green = 204;
+  };
+  surface0 = {
+    hex = "ccd0da";
+    red = 204;
+    blue = 208;
+    green = 218;
+  };
+  base = {
+    hex = "eff1f5";
+    red = 239;
+    blue = 241;
+    green = 245;
+  };
+  mantle = {
+    hex = "e6e9ef";
+    red = 230;
+    blue = 233;
+    green = 239;
+  };
+  crust = {
+    hex = "dce0e8";
+    red = 220;
+    blue = 224;
+    green = 232;
+  };
+}

--- a/nix/macchiato.nix
+++ b/nix/macchiato.nix
@@ -1,0 +1,158 @@
+{
+  rosewater = {
+    hex = "f4dbd6";
+    red = 244;
+    green = 219;
+    blue = 214;
+  };
+  flamingo = {
+    hex = "f0c6c6";
+    red = 240;
+    green = 198;
+    blue = 198;
+  };
+  pink = {
+    hex = "f5bde6";
+    red = 245;
+    green = 189;
+    blue = 230;
+  };
+  mauve = {
+    hex = "c6a0f6";
+    red = 198;
+    green = 160;
+    blue = 246;
+  };
+  red = {
+    hex = "ed8796";
+    red = 237;
+    green = 135;
+    blue = 150;
+  };
+  maroon = {
+    hex = "ee99a0";
+    red = 238;
+    green = 153;
+    blue = 160;
+  };
+  peach = {
+    hex = "f5a97f";
+    red = 245;
+    green = 169;
+    blue = 127;
+  };
+  yellow = {
+    hex = "eed49f";
+    red = 238;
+    green = 212;
+    blue = 159;
+  };
+  green = {
+    hex = "a6da95";
+    red = 166;
+    green = 218;
+    blue = 149;
+  };
+  teal = {
+    hex = "8bd5ca";
+    red = 139;
+    green = 213;
+    blue = 202;
+  };
+  sky = {
+    hex = "91d7e3";
+    red = 145;
+    green = 215;
+    blue = 227;
+  };
+  sapphire = {
+    hex = "7dc4e4";
+    red = 125;
+    green = 196;
+    blue = 228;
+  };
+  blue = {
+    hex = "8aadf4";
+    red = 138;
+    green = 173;
+    blue = 244;
+  };
+  lavender = {
+    hex = "b7bdf8";
+    red = 183;
+    green = 189;
+    blue = 248;
+  };
+  text = {
+    hex = "cad3f5";
+    red = 202;
+    green = 211;
+    blue = 245;
+  };
+  subtext1 = {
+    hex = "b8c0e0";
+    red = 184;
+    green = 192;
+    blue = 224;
+  };
+  subtext0 = {
+    hex = "a5adcb";
+    red = 165;
+    green = 173;
+    blue = 203;
+  };
+  overlay2 = {
+    hex = "939ab7";
+    red = 147;
+    green = 154;
+    blue = 183;
+  };
+  overlay1 = {
+    hex = "8087a2";
+    red = 128;
+    green = 135;
+    blue = 162;
+  };
+  overlay0 = {
+    hex = "6e738d";
+    red = 110;
+    green = 115;
+    blue = 141;
+  };
+  surface2 = {
+    hex = "5b6078";
+    red = 91;
+    green = 96;
+    blue = 120;
+  };
+  surface1 = {
+    hex = "494d64";
+    red = 73;
+    green = 77;
+    blue = 100;
+  };
+  surface0 = {
+    hex = "363a4f";
+    red = 54;
+    green = 58;
+    blue = 79;
+  };
+  base = {
+    hex = "24273a";
+    red = 36;
+    green = 39;
+    blue = 58;
+  };
+  mantle = {
+    hex = "1e2030";
+    red = 30;
+    green = 32;
+    blue = 48;
+  };
+  crust = {
+    hex = "181926";
+    red = 24;
+    green = 25;
+    blue = 38;
+  };
+}

--- a/nix/mocha.nix
+++ b/nix/mocha.nix
@@ -1,0 +1,158 @@
+{
+  rosewater = {
+    hex = "f5e0dc";
+    red = 245;
+    green = 224;
+    blue = 220;
+  };
+  flamingo = {
+    hex = "f2cdcd";
+    red = 242;
+    green = 205;
+    blue = 205;
+  };
+  pink = {
+    hex = "f5c2e7";
+    red = 245;
+    green = 194;
+    blue = 231;
+  };
+  mauve = {
+    hex = "cba6f7";
+    red = 203;
+    green = 166;
+    blue = 247;
+  };
+  red = {
+    hex = "f38ba8";
+    red = 243;
+    green = 139;
+    blue = 168;
+  };
+  maroon = {
+    hex = "eba0ac";
+    red = 235;
+    green = 160;
+    blue = 172;
+  };
+  peach = {
+    hex = "fab387";
+    red = 250;
+    green = 179;
+    blue = 135;
+  };
+  yellow = {
+    hex = "f9e2af";
+    red = 249;
+    green = 226;
+    blue = 175;
+  };
+  green = {
+    hex = "a6e3a1";
+    red = 166;
+    green = 227;
+    blue = 161;
+  };
+  teal = {
+    hex = "94e2d5";
+    red = 148;
+    green = 226;
+    blue = 213;
+  };
+  sky = {
+    hex = "89dceb";
+    red = 137;
+    green = 220;
+    blue = 235;
+  };
+  sapphire = {
+    hex = "74c7ec";
+    red = 116;
+    green = 199;
+    blue = 236;
+  };
+  blue = {
+    hex = "89b4fa";
+    red = 137;
+    green = 180;
+    blue = 250;
+  };
+  lavender = {
+    hex = "b4befe";
+    red = 180;
+    green = 190;
+    blue = 254;
+  };
+  text = {
+    hex = "cdd6f4";
+    red = 205;
+    green = 214;
+    blue = 244;
+  };
+  subtext1 = {
+    hex = "bac2de";
+    red = 186;
+    green = 194;
+    blue = 222;
+  };
+  subtext0 = {
+    hex = "a6adc8";
+    red = 166;
+    green = 173;
+    blue = 200;
+  };
+  overlay2 = {
+    hex = "9399b2";
+    red = 147;
+    green = 153;
+    blue = 178;
+  };
+  overlay1 = {
+    hex = "7f849c";
+    red = 127;
+    green = 132;
+    blue = 156;
+  };
+  overlay0 = {
+    hex = "6c7086";
+    red = 108;
+    green = 112;
+    blue = 134;
+  };
+  surface2 = {
+    hex = "585b70";
+    red = 88;
+    green = 91;
+    blue = 112;
+  };
+  surface1 = {
+    hex = "45475a";
+    red = 69;
+    green = 71;
+    blue = 90;
+  };
+  surface0 = {
+    hex = "313244";
+    red = 49;
+    green = 50;
+    blue = 68;
+  };
+  base = {
+    hex = "1e1e2e";
+    red = 30;
+    green = 30;
+    blue = 46;
+  };
+  mantle = {
+    hex = "181825";
+    red = 24;
+    green = 24;
+    blue = 37;
+  };
+  crust = {
+    hex = "11111b";
+    red = 17;
+    green = 17;
+    blue = 27;
+  };
+}


### PR DESCRIPTION
I often end up hardcoding catppuccin colors in my home-manager config, which breaks my global flavour and accent options. Having something like this would remove the need to do that.

Feedback welcome!