### PR TITLE
Palette naming

### DIFF
--- a/gpl/Catppuccin Frappe.gpl
+++ b/gpl/Catppuccin Frappe.gpl
@@ -1,5 +1,5 @@
 GIMP Palette
-#Palette Name: Catppuccin Frappe
+Name: Catppuccin Frappe
 #Colors: 26
 242 213 207 f2d5cf
 238 190 190 eebebe

--- a/gpl/Catppuccin Latte.gpl
+++ b/gpl/Catppuccin Latte.gpl
@@ -1,5 +1,5 @@
 GIMP Palette
-#Palette Name: Catppuccin Latte
+Name: Catppuccin Latte
 #Colors: 26
 220 138 120 dc8a78
 221 120 120 dd7878

--- a/gpl/Catppuccin Macchiato.gpl
+++ b/gpl/Catppuccin Macchiato.gpl
@@ -1,5 +1,5 @@
 GIMP Palette
-#Palette Name: Catppuccin Macchiato
+Name: Catppuccin Macchiato
 #Colors: 26
 244 219 214 f4dbd6
 240 198 198 f0c6c6

--- a/gpl/Catppuccin Mocha.gpl
+++ b/gpl/Catppuccin Mocha.gpl
@@ -1,5 +1,5 @@
 GIMP Palette
-#Palette Name: Catppuccin Mocha
+Name: Catppuccin Mocha
 #Colors: 26
 245 224 220 f5e0dc
 242 205 205 f2cdcd


### PR DESCRIPTION
Inkscape and GIMP seem to take their palette names from a line starting with `Name` rather than `#Palette Name`. Hope this does not break anything else.