### PR TITLE
Incorrect CSS usage.

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -25,7 +25,7 @@ Then use them:
 
 ```css
 .my-div {
-  color:        var(--ctp-mocha-text-hex);
+  color:        var(--ctp-mocha-text);
   background:   rgba(var(--ctp-macchiato-base-rgb) 0.9);
   border-color: hsla(var(--ctp-frappe-red-hsl) 0.75);
 }


### PR DESCRIPTION
According to the built UNPKG version, it is used as:
```css
.my-div {
  color:        var(--ctp-mocha-text);
  background:   rgba(var(--ctp-macchiato-base-rgb) 0.9);
  border-color: hsla(var(--ctp-frappe-red-hsl) 0.75);
}
```
not
```css
.my-div {
  color:        var(--ctp-mocha-text-hex);
  background:   rgba(var(--ctp-macchiato-base-rgb) 0.9);
  border-color: hsla(var(--ctp-frappe-red-hsl) 0.75);
}
```