### PR TITLE
build: publish to JSR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,6 +52,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
+      - name: Publish to JSR
+        run: deno publish
+
       - name: Upload the palette files
         env:
           GH_TOKEN: ${{ github.token }}

--- a/deno.json
+++ b/deno.json
@@ -1,4 +1,7 @@
 {
+  "name": "@catppuccin/palette",
+  "version": "1.1.0",
+  "exports": "./mod.ts",
   "importMap": "./import_map.json",
   "exclude": [
     "dist"
@@ -13,6 +16,5 @@
     "build:palettes": "deno run -A ./scripts/build_palettes.ts",
     "build": "deno task build:npm & deno task build:palettes",
     "generate": "deno run -A ./scripts/gen_palette.ts"
-  },
-  "version": "1.1.0"
+  }
 }

--- a/mod.ts
+++ b/mod.ts
@@ -185,7 +185,7 @@ export type ColorFormat = Readonly<{
 /**
  * All flavors of Catppuccin
  */
-export const flavors = entriesFromObject(definitions)
+export const flavors: CatppuccinFlavors = entriesFromObject(definitions)
   .reduce((acc, [flavorName, flavor]) => {
     acc[flavorName] = {
       ...flavor,
@@ -197,4 +197,6 @@ export const flavors = entriesFromObject(definitions)
 /**
  * A typed `Object.entries()` iterable of all Catppuccin flavors
  */
-export const flavorEntries = entriesFromObject(flavors);
+export const flavorEntries: Entries<CatppuccinFlavors> = entriesFromObject(
+  flavors,
+);


### PR DESCRIPTION
[JSR](https://jsr.io/docs/introduction) is a new registry service by Deno. We already publish to denoland and I believe its trivial to also upload to JSR. 

[denoland vs JSR:](https://jsr.io/docs/other-registries#denolandx)

![image](https://github.com/catppuccin/palette/assets/58985301/21fb02a7-dd23-4345-9898-4c5567850b54)

BEGIN_COMMIT_OVERRIDE
build: publish to JSR
refactor: add explicit types for JSR
END_COMMIT_OVERRIDE