### PR TITLE
feat: add support for apple color list / .clr files

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Build
         run: deno task build
+        env:
+          COMPILE_APPLE_COLOR_LIST: 1
 
       - name: Publish NPM package
         working-directory: dist/npm

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created || github.event.inputs.force_release }}
     steps:
@@ -42,6 +42,10 @@ jobs:
         with:
           node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
+
+      - uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "5"
 
       - name: Build
         run: deno task build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,9 @@ jobs:
         run: deno task build
         env:
           COMPILE_APPLE_COLOR_LIST: 1
+
+      - name: Upload Built Palette Formats
+        uses: actions/upload-artifact@v4
+        with:
+          name: "Catppuccin Palette Formats"
+          path: dist/palettes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,12 +8,16 @@ on:
 jobs:
   main:
     name: Lint and test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: nekowinston/setup-deno@v1
+
+      - uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "5"
 
       - uses: actions/setup-node@v4
         with:
@@ -29,4 +33,6 @@ jobs:
         run: deno test --doc
 
       - name: Test Deno dnt
-        run: deno task build:npm
+        run: deno task build
+        env:
+          COMPILE_APPLE_COLOR_LIST: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Test
         run: deno test --doc
 
-      - name: Test Deno dnt
+      - name: Build
         run: deno task build
         env:
           COMPILE_APPLE_COLOR_LIST: 1

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Please use the respective files in [the latest GitHub Release](https://github.co
 | Adobe Suite, Affinity Suite, Sip | `ase/`       |
 | Aseprite, Gimp, Inkscape, Krita  | `gimp/`      |
 | Procreate                        | `procreate/` |
+| Apple Color List (.clr)          | `clr/`       |
 
 &nbsp;
 

--- a/deno.lock
+++ b/deno.lock
@@ -2,9 +2,14 @@
   "version": "3",
   "packages": {
     "specifiers": {
+      "npm:@types/node": "npm:@types/node@18.16.19",
       "npm:chalk@5": "npm:chalk@5.3.0"
     },
     "npm": {
+      "@types/node@18.16.19": {
+        "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
+        "dependencies": {}
+      },
       "chalk@5.3.0": {
         "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
         "dependencies": {}

--- a/scripts/build_palettes.ts
+++ b/scripts/build_palettes.ts
@@ -4,6 +4,7 @@ import { join } from "std/path/mod.ts";
 import { flavors } from "@catppuccin/palette";
 import {
   generateAse,
+  generateClrJson,
   generateGimp,
   generatePng,
   generateProcreate,
@@ -14,14 +15,14 @@ const ROOT = new URL("../dist/palettes", import.meta.url).pathname;
 await emptyDir(ROOT);
 
 await Promise.all(
-  ["ase", "gimp", "procreate", "png", "sip"].map((folder) =>
+  ["ase", "gimp", "procreate", "png", "sip", "clr"].map((folder) =>
     ensureDir(join(ROOT, folder))
   ),
 );
 
 Promise.all(
-  Object.entries(flavors).flatMap(async ([name, { colors }]) => {
-    const fname = name.charAt(0).toUpperCase() + name.slice(1);
+  Object.entries(flavors).flatMap(async ([identifier, { name, colors }]) => {
+    const fname = identifier.charAt(0).toUpperCase() + identifier.slice(1);
 
     await Deno.writeFile(
       join(ROOT, `ase/${fname}.ase`),
@@ -43,5 +44,26 @@ Promise.all(
       join(ROOT, `sip/${fname}.palette`),
       generateSip(fname, colors),
     );
+
+    const clrJson = join(ROOT, `clr/${fname}.json`);
+    await Deno.writeTextFile(
+      clrJson,
+      generateClrJson(fname, colors),
+    );
+    const cmd = new Deno.Command("swift", {
+      args: [
+        join(import.meta.dirname!, "./builders/palettes/json-to-clr.swift"),
+        clrJson,
+        join(ROOT, `clr/Catppuccin ${name}.clr`),
+      ],
+    });
+    const { code, stderr, stdout } = await cmd.output();
+    const td = new TextDecoder();
+    if (code === 0) {
+      console.log(td.decode(stdout).trim());
+    } else {
+      throw new Error(td.decode(stderr));
+    }
+    await Deno.remove(clrJson);
   }),
 ).then(() => Deno.exit(0));

--- a/scripts/build_palettes.ts
+++ b/scripts/build_palettes.ts
@@ -45,25 +45,29 @@ Promise.all(
       generateSip(fname, colors),
     );
 
-    const clrJson = join(ROOT, `clr/${fname}.json`);
-    await Deno.writeTextFile(
-      clrJson,
-      generateClrJson(fname, colors),
-    );
-    const cmd = new Deno.Command("swift", {
-      args: [
-        join(import.meta.dirname!, "./builders/palettes/json-to-clr.swift"),
+    if (Deno.env.get("COMPILE_APPLE_COLOR_LIST") === "1") {
+      const clrJson = join(ROOT, `clr/${fname}.json`);
+      await Deno.writeTextFile(
         clrJson,
-        join(ROOT, `clr/Catppuccin ${name}.clr`),
-      ],
-    });
-    const { code, stderr, stdout } = await cmd.output();
-    const td = new TextDecoder();
-    if (code === 0) {
-      console.log(td.decode(stdout).trim());
-    } else {
-      throw new Error(td.decode(stderr));
+        generateClrJson(fname, colors),
+      );
+
+      const cmd = new Deno.Command("swift", {
+        args: [
+          join(import.meta.dirname!, "./builders/palettes/json-to-clr.swift"),
+          clrJson,
+          join(ROOT, `clr/${name}.clr`),
+        ],
+      });
+      const { code, stderr, stdout } = await cmd.output();
+      const td = new TextDecoder();
+      if (code === 0) {
+        console.log(td.decode(stdout).trim());
+      } else {
+        throw new Error(td.decode(stderr));
+      }
+
+      await Deno.remove(clrJson);
     }
-    await Deno.remove(clrJson);
   }),
 ).then(() => Deno.exit(0));

--- a/scripts/builders/mod.ts
+++ b/scripts/builders/mod.ts
@@ -7,3 +7,4 @@ export { generateGimp } from "./palettes/gimp.ts";
 export { generatePng } from "./palettes/png.ts";
 export { generateProcreate } from "./palettes/procreate.ts";
 export { generateSip } from "./palettes/sip.ts";
+export { generateClrJson } from "./palettes/clr.ts";

--- a/scripts/builders/palettes/clr.ts
+++ b/scripts/builders/palettes/clr.ts
@@ -1,0 +1,15 @@
+import type { CatppuccinColors } from "@catppuccin/palette";
+
+export const generateClrJson = (
+  _name: string,
+  palette: CatppuccinColors,
+): string => {
+  const data: Record<string, { hex: string; order: number }> = Object
+    .fromEntries(
+      Object.entries(palette).map(([_, { name, hex, order }]) => {
+        return [name, { hex, order }];
+      }),
+    );
+
+  return JSON.stringify(data);
+};

--- a/scripts/builders/palettes/json-to-clr.swift
+++ b/scripts/builders/palettes/json-to-clr.swift
@@ -50,11 +50,8 @@ func convertJSONToCLR(inputFilePath: String, outputFilePath: String) {
 }
 
 if CommandLine.argc != 3 {
-  print("Not enough arguments provided")
+  print("\(CommandLine.arguments[0]): Not enough arguments provided (expected input and output filenames)")
   exit(1)
 }
 
-let inputFilePath = CommandLine.arguments[1]
-let outputFilePath = CommandLine.arguments[2]
-
-convertJSONToCLR(inputFilePath: inputFilePath, outputFilePath: outputFilePath)
+convertJSONToCLR(inputFilePath: CommandLine.arguments[1], outputFilePath: CommandLine.arguments[2])

--- a/scripts/builders/palettes/json-to-clr.swift
+++ b/scripts/builders/palettes/json-to-clr.swift
@@ -1,70 +1,72 @@
-import Foundation
 import AppKit
+import Foundation
 
 struct ColorProperties: Decodable {
-    let hex: String
-    let order: Int
+  let hex: String
+  let order: Int
 }
 
 typealias ColorList = [String: ColorProperties]
 
 func hex2rgba(_ color: String) -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
-    var hexColor = color
-    if hexColor.hasPrefix("#") {
-        hexColor.remove(at: hexColor.startIndex)
-    }
+  var hexColor = color
+  if hexColor.hasPrefix("#") {
+    hexColor.remove(at: hexColor.startIndex)
+  }
 
-    switch hexColor.count {
-    case 3, 4:
-        hexColor = hexColor.reduce("") { $0 + String(repeating: String($1), count: 2) }
-        fallthrough
-    case 6, 8:
-        if hexColor.count == 6 {
-            hexColor += "ff"
-        }
-        let r = CGFloat(Int(hexColor.prefix(2), radix: 16) ?? 0) / 255
-        let g = CGFloat(Int(hexColor.dropFirst(2).prefix(2), radix: 16) ?? 0) / 255
-        let b = CGFloat(Int(hexColor.dropFirst(4).prefix(2), radix: 16) ?? 0) / 255
-        let a = CGFloat(Int(hexColor.dropFirst(6).prefix(2), radix: 16) ?? 0) / 255
-        return (r, g, b, a)
-    default:
-        return (0, 0, 0, 0)
+  switch hexColor.count {
+  case 3, 4:
+    hexColor = hexColor.reduce("") { $0 + String(repeating: String($1), count: 2) }
+    fallthrough
+  case 6, 8:
+    if hexColor.count == 6 {
+      hexColor += "ff"
     }
+    let r = CGFloat(Int(hexColor.prefix(2), radix: 16) ?? 0) / 255
+    let g = CGFloat(Int(hexColor.dropFirst(2).prefix(2), radix: 16) ?? 0) / 255
+    let b = CGFloat(Int(hexColor.dropFirst(4).prefix(2), radix: 16) ?? 0) / 255
+    let a = CGFloat(Int(hexColor.dropFirst(6).prefix(2), radix: 16) ?? 0) / 255
+    return (r, g, b, a)
+  default:
+    return (0, 0, 0, 0)
+  }
 }
 
 func convertJSONToCLR(inputFilePath: String, outputFilePath: String) {
-    let url = URL(fileURLWithPath: inputFilePath)
-    guard let data = try? Data(contentsOf: url),
-          let colorList = try? JSONDecoder().decode(ColorList.self, from: data) else {
-        print("Failed to read or parse JSON file.")
-        return
-    }
+  let url = URL(fileURLWithPath: inputFilePath)
+  guard let data = try? Data(contentsOf: url),
+    let colorList = try? JSONDecoder().decode(ColorList.self, from: data)
+  else {
+    print("Failed to read or parse JSON file.")
+    return
+  }
 
-    let sortedColors = colorList.sorted { (lhs, rhs) -> Bool in
-        return lhs.value.order < rhs.value.order
-    }
+  let sortedColors = colorList.sorted { (lhs, rhs) -> Bool in
+    return lhs.value.order < rhs.value.order
+  }
 
-    let paletteName = url.deletingPathExtension().lastPathComponent
-    let nsColorList = NSColorList(name: paletteName)
+  let paletteName = url.deletingPathExtension().lastPathComponent
+  let nsColorList = NSColorList(name: paletteName)
 
-    for (name, properties) in sortedColors {
-        let hex = properties.hex
-        let color = hex2rgba(hex)
-        nsColorList.setColor(NSColor(calibratedRed: color.r, green: color.g, blue: color.b, alpha: color.a), forKey: name)
-    }
+  for (name, properties) in sortedColors {
+    let hex = properties.hex
+    let color = hex2rgba(hex)
+    nsColorList.setColor(
+      NSColor(calibratedRed: color.r, green: color.g, blue: color.b, alpha: color.a), forKey: name)
+  }
 
-    let clrFilePath = URL(fileURLWithPath: outputFilePath)
-    do {
-        try nsColorList.write(to: clrFilePath)
-        print("Successfully saved palette to \(outputFilePath).")
-    } catch {
-        print("Failed to save color palette: \(error)")
-    }
+  let clrFilePath = URL(fileURLWithPath: outputFilePath)
+  do {
+    try nsColorList.write(to: clrFilePath)
+    print("Successfully saved palette to \(outputFilePath).")
+  } catch {
+    print("Failed to save color palette: \(error)")
+  }
 }
 
 if CommandLine.argc != 3 {
-    print("Usage: swift ./json-to-clr.swift <INPUT> <OUTPUT>")
-    exit(1)
+  print("Usage: swift ./json-to-clr.swift <INPUT> <OUTPUT>")
+  exit(1)
 }
 
 let inputFilePath = CommandLine.arguments[1]

--- a/scripts/builders/palettes/json-to-clr.swift
+++ b/scripts/builders/palettes/json-to-clr.swift
@@ -8,14 +8,13 @@ struct ColorProperties: Decodable {
 
 typealias ColorList = [String: ColorProperties]
 
-func hexToRGBA(_ color: String) -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
-  var hexColor = String(color.dropFirst()) + "ff"
+func hexToRGBA(_ color: String) -> (r: CGFloat, g: CGFloat, b: CGFloat) {
+  var hexColor = String(color.dropFirst())
 
   let r = CGFloat(Int(hexColor.prefix(2), radix: 16) ?? 0) / 255
   let g = CGFloat(Int(hexColor.dropFirst(2).prefix(2), radix: 16) ?? 0) / 255
   let b = CGFloat(Int(hexColor.dropFirst(4).prefix(2), radix: 16) ?? 0) / 255
-  let a = CGFloat(Int(hexColor.dropFirst(6).prefix(2), radix: 16) ?? 0) / 255
-  return (r, g, b, a)
+  return (r, g, b)
 }
 
 func convertJSONToCLR(inputFilePath: String, outputFilePath: String) {
@@ -38,7 +37,7 @@ func convertJSONToCLR(inputFilePath: String, outputFilePath: String) {
     let hex = properties.hex
     let color = hexToRGBA(hex)
     nsColorList.setColor(
-      NSColor(calibratedRed: color.r, green: color.g, blue: color.b, alpha: color.a), forKey: name)
+      NSColor(red: color.r, green: color.g, blue: color.b, alpha: 1), forKey: name)
   }
 
   let clrFilePath = URL(fileURLWithPath: outputFilePath)

--- a/scripts/builders/palettes/json-to-clr.swift
+++ b/scripts/builders/palettes/json-to-clr.swift
@@ -9,27 +9,13 @@ struct ColorProperties: Decodable {
 typealias ColorList = [String: ColorProperties]
 
 func hexToRGBA(_ color: String) -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
-  var hexColor = color
-  if hexColor.hasPrefix("#") {
-    hexColor.remove(at: hexColor.startIndex)
-  }
+  var hexColor = String(color.dropFirst()) + "ff"
 
-  switch hexColor.count {
-  case 3, 4:
-    hexColor = hexColor.reduce("") { $0 + String(repeating: String($1), count: 2) }
-    fallthrough
-  case 6, 8:
-    if hexColor.count == 6 {
-      hexColor += "ff"
-    }
-    let r = CGFloat(Int(hexColor.prefix(2), radix: 16) ?? 0) / 255
-    let g = CGFloat(Int(hexColor.dropFirst(2).prefix(2), radix: 16) ?? 0) / 255
-    let b = CGFloat(Int(hexColor.dropFirst(4).prefix(2), radix: 16) ?? 0) / 255
-    let a = CGFloat(Int(hexColor.dropFirst(6).prefix(2), radix: 16) ?? 0) / 255
-    return (r, g, b, a)
-  default:
-    return (0, 0, 0, 0)
-  }
+  let r = CGFloat(Int(hexColor.prefix(2), radix: 16) ?? 0) / 255
+  let g = CGFloat(Int(hexColor.dropFirst(2).prefix(2), radix: 16) ?? 0) / 255
+  let b = CGFloat(Int(hexColor.dropFirst(4).prefix(2), radix: 16) ?? 0) / 255
+  let a = CGFloat(Int(hexColor.dropFirst(6).prefix(2), radix: 16) ?? 0) / 255
+  return (r, g, b, a)
 }
 
 func convertJSONToCLR(inputFilePath: String, outputFilePath: String) {

--- a/scripts/builders/palettes/json-to-clr.swift
+++ b/scripts/builders/palettes/json-to-clr.swift
@@ -8,7 +8,7 @@ struct ColorProperties: Decodable {
 
 typealias ColorList = [String: ColorProperties]
 
-func hex2rgba(_ color: String) -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+func hexToRGBA(_ color: String) -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
   var hexColor = color
   if hexColor.hasPrefix("#") {
     hexColor.remove(at: hexColor.startIndex)
@@ -50,7 +50,7 @@ func convertJSONToCLR(inputFilePath: String, outputFilePath: String) {
 
   for (name, properties) in sortedColors {
     let hex = properties.hex
-    let color = hex2rgba(hex)
+    let color = hexToRGBA(hex)
     nsColorList.setColor(
       NSColor(calibratedRed: color.r, green: color.g, blue: color.b, alpha: color.a), forKey: name)
   }
@@ -65,7 +65,7 @@ func convertJSONToCLR(inputFilePath: String, outputFilePath: String) {
 }
 
 if CommandLine.argc != 3 {
-  print("Usage: swift ./json-to-clr.swift <INPUT> <OUTPUT>")
+  print("Not enough arguments provided")
   exit(1)
 }
 

--- a/scripts/builders/palettes/json-to-clr.swift
+++ b/scripts/builders/palettes/json-to-clr.swift
@@ -1,0 +1,73 @@
+import Foundation
+import AppKit
+
+struct ColorProperties: Decodable {
+    let hex: String
+    let order: Int
+}
+
+typealias ColorList = [String: ColorProperties]
+
+func hex2rgba(_ color: String) -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+    var hexColor = color
+    if hexColor.hasPrefix("#") {
+        hexColor.remove(at: hexColor.startIndex)
+    }
+
+    switch hexColor.count {
+    case 3, 4:
+        hexColor = hexColor.reduce("") { $0 + String(repeating: String($1), count: 2) }
+        fallthrough
+    case 6, 8:
+        if hexColor.count == 6 {
+            hexColor += "ff"
+        }
+        let r = CGFloat(Int(hexColor.prefix(2), radix: 16) ?? 0) / 255
+        let g = CGFloat(Int(hexColor.dropFirst(2).prefix(2), radix: 16) ?? 0) / 255
+        let b = CGFloat(Int(hexColor.dropFirst(4).prefix(2), radix: 16) ?? 0) / 255
+        let a = CGFloat(Int(hexColor.dropFirst(6).prefix(2), radix: 16) ?? 0) / 255
+        return (r, g, b, a)
+    default:
+        return (0, 0, 0, 0)
+    }
+}
+
+func convertJSONToCLR(inputFilePath: String, outputFilePath: String) {
+    let url = URL(fileURLWithPath: inputFilePath)
+    guard let data = try? Data(contentsOf: url),
+          let colorList = try? JSONDecoder().decode(ColorList.self, from: data) else {
+        print("Failed to read or parse JSON file.")
+        return
+    }
+
+    let sortedColors = colorList.sorted { (lhs, rhs) -> Bool in
+        return lhs.value.order < rhs.value.order
+    }
+
+    let paletteName = url.deletingPathExtension().lastPathComponent
+    let nsColorList = NSColorList(name: paletteName)
+
+    for (name, properties) in sortedColors {
+        let hex = properties.hex
+        let color = hex2rgba(hex)
+        nsColorList.setColor(NSColor(calibratedRed: color.r, green: color.g, blue: color.b, alpha: color.a), forKey: name)
+    }
+
+    let clrFilePath = URL(fileURLWithPath: outputFilePath)
+    do {
+        try nsColorList.write(to: clrFilePath)
+        print("Successfully saved palette to \(outputFilePath).")
+    } catch {
+        print("Failed to save color palette: \(error)")
+    }
+}
+
+if CommandLine.argc != 3 {
+    print("Usage: swift ./json-to-clr.swift <INPUT> <OUTPUT>")
+    exit(1)
+}
+
+let inputFilePath = CommandLine.arguments[1]
+let outputFilePath = CommandLine.arguments[2]
+
+convertJSONToCLR(inputFilePath: inputFilePath, outputFilePath: outputFilePath)

--- a/types/procreate-swatches.d.ts
+++ b/types/procreate-swatches.d.ts
@@ -1,9 +1,11 @@
+import type { Buffer } from "node:buffer";
+
 type ColorSpace = "rgb" | "hsl" | "hsv" | "hwb" | "xyz" | "lab" | "lch";
 type Colors = [number[], ColorSpace][];
 
 export function readSwatchesFile(
   data: string | Uint8Array | ArrayBuffer | Blob,
-  colorSpace?: ColorSpace
+  colorSpace?: ColorSpace,
 ): Promise<{
   name: string;
   colors: Colors;
@@ -21,11 +23,11 @@ type SwatchReturnType = {
 };
 
 export function createSwatchesFile<
-  F extends keyof SwatchReturnType | undefined = undefined
+  F extends keyof SwatchReturnType | undefined = undefined,
 >(
   name: string,
   colors: Colors,
-  format?: F
+  format?: F,
 ): Promise<F extends keyof SwatchReturnType ? SwatchReturnType[F] : Uint8Array>;
 
 interface ProcreateSwatchesError extends Error {


### PR DESCRIPTION
Brings https://github.com/uncenter/ctp-clr to this repository. I would like to add instructions for how exactly to use these files but it doesn't look like we have any existing instructions for the other palette files / apps.