### PR TITLE
fix: CSS RGB/HSL variables (Alpha usage)

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -26,8 +26,8 @@ Then use them:
 ```css
 .my-div {
   color:        var(--ctp-mocha-text);
-  background:   rgba(var(--ctp-macchiato-base-rgb) 0.9);
-  border-color: hsla(var(--ctp-frappe-red-hsl) 0.75);
+  background:   rgba(var(--ctp-macchiato-base-rgb), 0.9);
+  border-color: hsla(var(--ctp-frappe-red-hsl), 0.75);
 }
 ```
 

--- a/scripts/builders/npm/css.ts
+++ b/scripts/builders/npm/css.ts
@@ -11,8 +11,8 @@ const template = flavorEntries
 
         return [
           sprintf("  %s: %s;", name, hex),
-          sprintf("  %s-rgb: %d %d %d;", name, ...Object.values(rgb)),
-          sprintf("  %s-hsl: %.3f %.3f%% %.3f%%;", name, h, s * 100, l * 100),
+          sprintf("  %s-rgb: %d, %d, %d;", name, ...Object.values(rgb)),
+          sprintf("  %s-hsl: %.3f, %.3f%%, %.3f%%;", name, h, s * 100, l * 100),
         ].join("\n");
       })
       .join("\n");


### PR DESCRIPTION
CSS variables are currently being built without commas in their declaration which is preventing them from working with alpha values. Adding in commas between the individual values fixes this issue and allows the variables to be used with `rgba` and `hsla` again.

### Changes in this PR

- Adds commas between individual `RGB`/`HSL` values during CSS build process
- Updates CSS usage documentation to include a comma for `rgba`/`hsla` usage

## Without commas (Previous)

Works without alpha
<img width="421" alt="Screenshot 2024-08-03 at 21 48 46" src="https://github.com/user-attachments/assets/fdbde9d5-8ec0-4b02-ab2a-3934118886f8">

Doesn't work with alpha
<img width="438" alt="Screenshot 2024-08-03 at 21 49 04" src="https://github.com/user-attachments/assets/d075d9de-2cfc-44d4-8ac1-1063e7ffe4d6">

## With commas (Fixed)

Works without alpha
<img width="432" alt="Screenshot 2024-08-03 at 21 49 46" src="https://github.com/user-attachments/assets/b47b6ac8-d4c0-4871-af69-2398fd359788">


Works with alpha
<img width="467" alt="Screenshot 2024-08-03 at 21 49 27" src="https://github.com/user-attachments/assets/a88b16ff-67ee-4074-b607-b972e6d050ce">