### PR TITLE
feat(palettes): prefix filenames with "Catppuccin"

### DIFF
--- a/scripts/build_palettes.ts
+++ b/scripts/build_palettes.ts
@@ -46,7 +46,7 @@ Promise.all(
     );
 
     if (Deno.env.get("COMPILE_APPLE_COLOR_LIST") === "1") {
-      const clrJson = join(ROOT, `clr/${name}.json`);
+      const clrJson = join(ROOT, `clr/${safeName}.json`);
       await Deno.writeTextFile(
         clrJson,
         generateClrJson(safeName, colors),

--- a/scripts/build_palettes.ts
+++ b/scripts/build_palettes.ts
@@ -21,53 +21,56 @@ await Promise.all(
 );
 
 Promise.all(
-  Object.entries(flavors).flatMap(async ([identifier, { name, colors }]) => {
-    const safeName = identifier.charAt(0).toUpperCase() + identifier.slice(1);
+  Object.entries(flavors).flatMap(
+    async ([identifier, { name: nameWithAccent, colors }]) => {
+      const nameWithoutAccent = identifier.charAt(0).toUpperCase() +
+        identifier.slice(1);
 
-    await Deno.writeFile(
-      join(ROOT, `ase/Catppuccin ${safeName}.ase`),
-      generateAse(safeName, colors),
-    );
-    await Deno.writeFile(
-      join(ROOT, `png/Catppuccin ${safeName}.png`),
-      generatePng(safeName, colors),
-    );
-    await Deno.writeFile(
-      join(ROOT, `procreate/Catppuccin ${safeName}.swatches`),
-      await generateProcreate(safeName, colors),
-    );
-    await Deno.writeTextFile(
-      join(ROOT, `gimp/Catppuccin ${safeName}.gpl`),
-      generateGimp(safeName, colors),
-    );
-    await Deno.writeTextFile(
-      join(ROOT, `sip/Catppuccin ${safeName}.palette`),
-      generateSip(safeName, colors),
-    );
-
-    if (Deno.env.get("COMPILE_APPLE_COLOR_LIST") === "1") {
-      const clrJson = join(ROOT, `clr/${safeName}.json`);
+      await Deno.writeFile(
+        join(ROOT, `ase/Catppuccin ${nameWithoutAccent}.ase`),
+        generateAse(nameWithoutAccent, colors),
+      );
+      await Deno.writeFile(
+        join(ROOT, `png/Catppuccin ${nameWithoutAccent}.png`),
+        generatePng(nameWithoutAccent, colors),
+      );
+      await Deno.writeFile(
+        join(ROOT, `procreate/Catppuccin ${nameWithoutAccent}.swatches`),
+        await generateProcreate(nameWithoutAccent, colors),
+      );
       await Deno.writeTextFile(
-        clrJson,
-        generateClrJson(safeName, colors),
+        join(ROOT, `gimp/Catppuccin ${nameWithoutAccent}.gpl`),
+        generateGimp(nameWithoutAccent, colors),
+      );
+      await Deno.writeTextFile(
+        join(ROOT, `sip/Catppuccin ${nameWithoutAccent}.palette`),
+        generateSip(nameWithoutAccent, colors),
       );
 
-      const cmd = new Deno.Command("swift", {
-        args: [
-          join(import.meta.dirname!, "./builders/palettes/json-to-clr.swift"),
+      if (Deno.env.get("COMPILE_APPLE_COLOR_LIST") === "1") {
+        const clrJson = join(ROOT, `clr/${nameWithoutAccent}.json`);
+        await Deno.writeTextFile(
           clrJson,
-          join(ROOT, `clr/Catppuccin ${name}.clr`),
-        ],
-      });
-      const { code, stderr, stdout } = await cmd.output();
-      const td = new TextDecoder();
-      if (code === 0) {
-        console.log(td.decode(stdout).trim());
-      } else {
-        throw new Error(td.decode(stderr));
-      }
+          generateClrJson(nameWithoutAccent, colors),
+        );
 
-      await Deno.remove(clrJson);
-    }
-  }),
+        const cmd = new Deno.Command("swift", {
+          args: [
+            join(import.meta.dirname!, "./builders/palettes/json-to-clr.swift"),
+            clrJson,
+            join(ROOT, `clr/Catppuccin ${nameWithAccent}.clr`),
+          ],
+        });
+        const { code, stderr, stdout } = await cmd.output();
+        const td = new TextDecoder();
+        if (code === 0) {
+          console.log(td.decode(stdout).trim());
+        } else {
+          throw new Error(td.decode(stderr));
+        }
+
+        await Deno.remove(clrJson);
+      }
+    },
+  ),
 ).then(() => Deno.exit(0));

--- a/scripts/build_palettes.ts
+++ b/scripts/build_palettes.ts
@@ -22,41 +22,41 @@ await Promise.all(
 
 Promise.all(
   Object.entries(flavors).flatMap(async ([identifier, { name, colors }]) => {
-    const fname = identifier.charAt(0).toUpperCase() + identifier.slice(1);
+    const safeName = identifier.charAt(0).toUpperCase() + identifier.slice(1);
 
     await Deno.writeFile(
-      join(ROOT, `ase/${fname}.ase`),
-      generateAse(fname, colors),
+      join(ROOT, `ase/Catppuccin ${safeName}.ase`),
+      generateAse(safeName, colors),
     );
     await Deno.writeFile(
-      join(ROOT, `png/${fname}.png`),
-      generatePng(fname, colors),
+      join(ROOT, `png/Catppuccin ${safeName}.png`),
+      generatePng(safeName, colors),
     );
     await Deno.writeFile(
-      join(ROOT, `procreate/${fname}.swatches`),
-      await generateProcreate(fname, colors),
+      join(ROOT, `procreate/Catppuccin ${safeName}.swatches`),
+      await generateProcreate(safeName, colors),
     );
     await Deno.writeTextFile(
-      join(ROOT, `gimp/${fname}.gpl`),
-      generateGimp(fname, colors),
+      join(ROOT, `gimp/Catppuccin ${safeName}.gpl`),
+      generateGimp(safeName, colors),
     );
     await Deno.writeTextFile(
-      join(ROOT, `sip/${fname}.palette`),
-      generateSip(fname, colors),
+      join(ROOT, `sip/Catppuccin ${safeName}.palette`),
+      generateSip(safeName, colors),
     );
 
     if (Deno.env.get("COMPILE_APPLE_COLOR_LIST") === "1") {
-      const clrJson = join(ROOT, `clr/${fname}.json`);
+      const clrJson = join(ROOT, `clr/${name}.json`);
       await Deno.writeTextFile(
         clrJson,
-        generateClrJson(fname, colors),
+        generateClrJson(safeName, colors),
       );
 
       const cmd = new Deno.Command("swift", {
         args: [
           join(import.meta.dirname!, "./builders/palettes/json-to-clr.swift"),
           clrJson,
-          join(ROOT, `clr/${name}.clr`),
+          join(ROOT, `clr/Catppuccin ${name}.clr`),
         ],
       });
       const { code, stderr, stdout } = await cmd.output();


### PR DESCRIPTION
Renames `fname` to `safeName` to clarify usage, prefixes all palette assets with "Catppuccin".