### PR TITLE
docs(sass.md): update maps to latest sass version (and fix minor mistake)

### DIFF
--- a/docs/sass.md
+++ b/docs/sass.md
@@ -54,10 +54,10 @@ In short:\
 Input:
 
 ```scss
+@use "sass:map";
 @use "catppuccin";
 // sass is also part of the npm package:
 // @use "~@catppuccin/palette/scss/catppuccin";
-@use "sass:map";
 
 @each $flavor, $color in catppuccin.$palette {
     .my-#{$flavor}-class {

--- a/docs/sass.md
+++ b/docs/sass.md
@@ -20,7 +20,7 @@ The easiest way to import a single flavor, is to use one of these 4 files:\
 
 Input:
 ```scss
-@import "mocha";
+@use "mocha";
 // sass is also part of the npm package:
 // @use "~@catppuccin/palette/scss/catppuccin/mocha";
 
@@ -47,9 +47,9 @@ is to use `_catppuccin.scss`.
 
 In short:\
 ❌ Don't do this:
-`#{map-get($color, blue)}`\
+`#{map.get($color, blue)}`\
 ✅ Do this:
-`#{map-get($color, 'blue')}`
+`#{map.get($color, 'blue')}`
 
 Input:
 
@@ -57,12 +57,13 @@ Input:
 @use "catppuccin";
 // sass is also part of the npm package:
 // @use "~@catppuccin/palette/scss/catppuccin";
+@use "sass:map";
 
 @each $flavor, $color in catppuccin.$palette {
-    .my-#{flavor}-class {
+    .my-#{$flavor}-class {
         // you need surround the catppuccin color names with quotes
-        background: map-get($color, 'base');
-        color: map-get($color, 'blue');
+        background: map.get($color, 'base');
+        color: map.get($color, 'blue');
     }
 }
 ```


### PR DESCRIPTION
sass doesn't do map-get now, you import @use "sass:map"; and use map.get()! and in the each it was missing a $, fixed too.

BEGIN_COMMIT_OVERRIDE
docs(sass): update maps syntax to latest sass version
END_COMMIT_OVERRIDE